### PR TITLE
Review build services PowerShell script

### DIFF
--- a/services/notebook-processor/Dockerfile
+++ b/services/notebook-processor/Dockerfile
@@ -33,8 +33,7 @@ COPY ${COMMON_PATH}/docker-base-images/notebook-processor-base/ijava-1.3.0.zip .
 # Install conda/mamba packages with cache mount
 # This caches conda packages on the build machine
 RUN --mount=type=cache,target=/opt/conda/pkgs \
-    micromamba install -y -n base -f /tmp/packages.yaml && \
-    micromamba clean --all --yes
+    micromamba install -y -n base -f /tmp/packages.yaml
 
 # Install system dependencies with apt cache
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \


### PR DESCRIPTION
Remove the 'micromamba clean --all' command that was running while the cache mount was active. This was deleting all cached packages immediately after installation, causing the cache to be empty on subsequent builds and forcing all packages to be re-downloaded every time.

Now the packages remain in the cache, significantly speeding up rebuilds.