### PR TITLE
Fix SessionStart hook environment detection for service modules

### DIFF
--- a/.claude/sessionStart
+++ b/.claude/sessionStart
@@ -9,7 +9,7 @@ echo "=== CLX SessionStart Hook ==="
 # Check if running in a remote environment (Claude Code on the web)
 # Remote environments typically don't have a USER environment variable set to a real username
 # or have specific Claude-related environment variables
-if [ -n "$CLAUDE_SESSION_ID" ] || [ "$USER" = "claude" ] || [ "$USER" = "root" ]; then
+if [ -n "$CLAUDE_CODE_SESSION_ID" ] || [ -n "$CLAUDE_SESSION_ID" ] || [ -n "$CLAUDE_CODE_REMOTE" ] || [ "$USER" = "claude" ] || [ "$(whoami)" = "root" ]; then
     echo "Remote environment detected. Installing dependencies..."
 
     # Install dependencies from requirements.txt


### PR DESCRIPTION
The SessionStart hook was not detecting the remote Claude Code environment
correctly, causing service modules (drawio-converter, notebook-processor,
plantuml-converter) to never be installed.

Root cause:
- Script checked for $CLAUDE_SESSION_ID but actual env var is $CLAUDE_CODE_SESSION_ID
- Script checked $USER = "root" but USER env var is not set in remote environment

Fix:
- Add check for $CLAUDE_CODE_SESSION_ID (the correct env var name)
- Add check for $CLAUDE_CODE_REMOTE as additional indicator
- Use $(whoami) instead of $USER to check if running as root
- Keep backward compatibility by checking both old and new env var names

This ensures the three service Python modules are properly installed during
session startup.