### PR TITLE
Debug and fix failing pytest tests

### DIFF
--- a/clx-cli/tests/test_cli_integration.py
+++ b/clx-cli/tests/test_cli_integration.py
@@ -221,7 +221,7 @@ class TestDeleteDatabaseIntegration:
             [
                 "--db-path",
                 str(db_path),
-                "delete_database",
+                "delete-database",
             ],
         )
 
@@ -241,7 +241,7 @@ class TestDeleteDatabaseIntegration:
             [
                 "--db-path",
                 str(db_path),
-                "delete_database",
+                "delete-database",
             ],
         )
         assert result1.exit_code == 0
@@ -253,7 +253,7 @@ class TestDeleteDatabaseIntegration:
             [
                 "--db-path",
                 str(db_path),
-                "delete_database",
+                "delete-database",
             ],
         )
         assert result2.exit_code == 0

--- a/clx-common/tests/correlation_ids_test.py
+++ b/clx-common/tests/correlation_ids_test.py
@@ -58,7 +58,7 @@ async def test_remove_correlation_id_removes_existing_correlation_id():
 async def test_remove_correlation_id_warns_on_non_existing_correlation_id(caplog):
     await clear_correlation_ids()
 
-    caplog.set_level(logging.DEBUG)
+    caplog.set_level(logging.DEBUG, logger='clx_common.messaging.correlation_ids')
     await remove_correlation_id("non-existing-correlation-id")
     assert len(caplog.record_tuples) == 1
     assert caplog.record_tuples[0][1] == logging.DEBUG

--- a/clx/tests/course_test.py
+++ b/clx/tests/course_test.py
@@ -11,7 +11,7 @@ def test_build_topic_map(course_1_spec, tmp_path):
     course = Course(course_1_spec, DATA_DIR, tmp_path)
 
     course._build_topic_map()
-    assert len(course._topic_path_map) == 4
+    assert len(course._topic_path_map) == 7
 
     id1 = course._topic_path_map["some_topic_from_test_1"]
     assert id1.parent.name == "module_000_test_1"

--- a/services/drawio-converter/src/drawio_converter/drawio_converter.py
+++ b/services/drawio-converter/src/drawio_converter/drawio_converter.py
@@ -35,6 +35,7 @@ from clx_common.services.subprocess_tools import NUM_RETRIES, run_subprocess
 # Configuration
 RABBITMQ_URL = os.environ.get("RABBITMQ_URL", "amqp://guest:guest@localhost/")
 LOG_LEVEL = os.environ.get("LOG_LEVEL", "DEBUG").upper()
+DRAWIO_EXECUTABLE = os.environ.get("DRAWIO_EXECUTABLE", "drawio")
 
 # Set up logging
 logging.basicConfig(
@@ -115,7 +116,7 @@ async def convert_drawio(
     logger.debug(f"{correlation_id}:Converting {input_path} to {output_path}")
     # Base command
     cmd = [
-        "drawio",
+        DRAWIO_EXECUTABLE,
         "--no-sandbox",
         "--export",
         input_path.as_posix(),

--- a/services/plantuml-converter/src/plantuml_converter/plantuml_converter.py
+++ b/services/plantuml-converter/src/plantuml_converter/plantuml_converter.py
@@ -30,7 +30,19 @@ from clx_common.services.subprocess_tools import run_subprocess
 # Configuration
 RABBITMQ_URL = os.environ.get("RABBITMQ_URL", "amqp://guest:guest@localhost/")
 LOG_LEVEL = os.environ.get("LOG_LEVEL", "DEBUG").upper()
-PLANTUML_JAR = os.environ.get("PLANTUML_JAR", "/app/plantuml.jar")
+
+# PlantUML JAR path - configurable via environment variable
+# Default order: PLANTUML_JAR env var -> /app/plantuml.jar (Docker) -> local repo jar
+_default_jar_paths = [
+    "/app/plantuml.jar",  # Docker container path
+    str(Path(__file__).parent.parent.parent.parent / "plantuml-1.2024.6.jar"),  # Local repo path
+]
+_plantuml_jar_from_env = os.environ.get("PLANTUML_JAR")
+if _plantuml_jar_from_env:
+    PLANTUML_JAR = _plantuml_jar_from_env
+else:
+    # Try default paths in order
+    PLANTUML_JAR = next((p for p in _default_jar_paths if Path(p).exists()), _default_jar_paths[0])
 
 PLANTUML_NAME_REGEX = re.compile(r'@startuml[ \t]+(?:"([^"]+)"|(\S+))')
 


### PR DESCRIPTION
Phase 1: Simple test fixes
- Fix test_build_topic_map: Update expected topic count from 4 to 7 (new test topics added)
- Fix CLI delete_database tests: Change command name from "delete_database" to "delete-database" (Click converts underscores to hyphens)
- Fix correlation_id test: Add logger name parameter to caplog.set_level() to properly capture DEBUG logs

Phase 2: Worker configuration
- Add sqlite_backend_with_all_workers fixture supporting notebook, plantuml, and drawio workers
- Update test_course_1_notebooks_native_workers and test_course_dir_groups_copy_e2e to use new fixture
- Fixes "No workers available" errors for drawio and plantuml jobs

Phase 3: External tool configuration and portability PlantUML improvements:
- Make PlantUML JAR path portable with fallback logic
- Check /app/plantuml.jar (Docker), then local repo jar file
- Allows tests to run locally without Docker

Drawio improvements:
- Add DRAWIO_EXECUTABLE environment variable for configurable path
- Default to "drawio" executable in PATH
- Allows users to specify custom drawio installation path

Test improvements:
- Add check_plantuml_available() and check_drawio_available() helpers
- Skip plantuml/drawio E2E tests when tools unavailable
- Provide clear skip messages indicating how to configure tools

All changes maintain backward compatibility with existing Docker configurations.