### PR TITLE
Implement  clx status command

### DIFF
--- a/src/clx/cli/main.py
+++ b/src/clx/cli/main.py
@@ -917,5 +917,82 @@ def workers_cleanup(db_path, force, cleanup_all):
     return 0
 
 
+@cli.command()
+@click.option(
+    "--db-path",
+    type=click.Path(exists=False, path_type=Path),
+    help="Path to SQLite database (auto-detected if not specified)",
+)
+@click.option(
+    "--workers",
+    "workers_only",
+    is_flag=True,
+    help="Show only worker information",
+)
+@click.option(
+    "--jobs",
+    "jobs_only",
+    is_flag=True,
+    help="Show only job queue information",
+)
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["table", "json", "compact"], case_sensitive=False),
+    default="table",
+    help="Output format",
+)
+@click.option(
+    "--no-color",
+    is_flag=True,
+    help="Disable colored output",
+)
+def status(db_path, workers_only, jobs_only, output_format, no_color):
+    """Show CLX system status.
+
+    Displays worker availability, job queue status, and system health.
+
+    Examples:
+
+        clx status                      # Show full status
+        clx status --workers            # Show only workers
+        clx status --format=json        # JSON output
+        clx status --db-path=/data/clx_jobs.db  # Custom database
+    """
+    from clx.cli.status.collector import StatusCollector
+    from clx.cli.status.formatters import (
+        CompactFormatter,
+        JsonFormatter,
+        TableFormatter,
+    )
+
+    # Create collector
+    collector = StatusCollector(db_path=db_path)
+
+    # Collect status
+    try:
+        status_info = collector.collect()
+    except Exception as e:
+        click.echo(f"Error collecting status: {e}", err=True)
+        logger.error(f"Error collecting status: {e}", exc_info=True)
+        return 2
+
+    # Create formatter
+    if output_format == "json":
+        formatter = JsonFormatter(pretty=True)
+    elif output_format == "compact":
+        formatter = CompactFormatter()
+    else:  # table
+        formatter = TableFormatter(use_color=not no_color)
+
+    # Format and display
+    output = formatter.format(status_info, workers_only=workers_only, jobs_only=jobs_only)
+    click.echo(output)
+
+    # Exit with appropriate code
+    exit_code = formatter.get_exit_code(status_info)
+    raise SystemExit(exit_code)
+
+
 if __name__ == "__main__":
     cli()

--- a/src/clx/cli/status/__init__.py
+++ b/src/clx/cli/status/__init__.py
@@ -1,0 +1,21 @@
+"""Status command for CLX."""
+
+from clx.cli.status.models import (
+    BusyWorkerInfo,
+    DatabaseInfo,
+    QueueStats,
+    StatusInfo,
+    SystemHealth,
+    WorkerStatus,
+    WorkerTypeStats,
+)
+
+__all__ = [
+    "BusyWorkerInfo",
+    "DatabaseInfo",
+    "QueueStats",
+    "StatusInfo",
+    "SystemHealth",
+    "WorkerStatus",
+    "WorkerTypeStats",
+]

--- a/src/clx/cli/status/collector.py
+++ b/src/clx/cli/status/collector.py
@@ -1,0 +1,408 @@
+"""Collect system status information from database."""
+
+import logging
+import os
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from clx.infrastructure.database.job_queue import JobQueue
+from clx.cli.status.models import (
+    BusyWorkerInfo,
+    DatabaseInfo,
+    QueueStats,
+    StatusInfo,
+    SystemHealth,
+    WorkerTypeStats,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class StatusCollector:
+    """Collect system status from database."""
+
+    HUNG_WORKER_THRESHOLD_SECONDS = 300  # 5 minutes
+    STALE_DATA_THRESHOLD_SECONDS = 60  # 1 minute
+    LONG_QUEUE_THRESHOLD = 10
+    OLD_PENDING_JOB_THRESHOLD_SECONDS = 300  # 5 minutes
+
+    def __init__(self, db_path: Optional[Path] = None):
+        """Initialize status collector.
+
+        Args:
+            db_path: Path to database. If None, use default location.
+        """
+        self.db_path = db_path or self._get_default_db_path()
+        self.job_queue: Optional[JobQueue] = None
+
+    def _get_default_db_path(self) -> Path:
+        """Get default database path from environment or config."""
+        # Check environment variable
+        db_path = os.getenv("CLX_DB_PATH")
+        if db_path:
+            return Path(db_path)
+
+        # Check current directory
+        default_paths = [
+            Path.cwd() / "clx_jobs.db",
+            Path.cwd() / "jobs.db",
+            Path.home() / ".clx" / "clx_jobs.db",
+        ]
+
+        for path in default_paths:
+            if path.exists():
+                return path
+
+        # Return default (may not exist yet)
+        return Path.cwd() / "clx_jobs.db"
+
+    def collect(self) -> StatusInfo:
+        """Collect complete system status.
+
+        Returns:
+            StatusInfo with all collected data
+        """
+        timestamp = datetime.now()
+
+        # Check database
+        db_info = self._collect_database_info()
+
+        if not db_info.accessible:
+            # Database not accessible - return error state
+            return StatusInfo(
+                timestamp=timestamp,
+                health=SystemHealth.ERROR,
+                database=db_info,
+                workers={},
+                queue=QueueStats(0, 0, 0, 0, None),
+                errors=[db_info.error_message or "Database not accessible"],
+            )
+
+        # Initialize job queue
+        try:
+            self.job_queue = JobQueue(self.db_path)
+        except Exception as e:
+            logger.error(f"Failed to initialize job queue: {e}", exc_info=True)
+            return StatusInfo(
+                timestamp=timestamp,
+                health=SystemHealth.ERROR,
+                database=db_info,
+                workers={},
+                queue=QueueStats(0, 0, 0, 0, None),
+                errors=[f"Failed to connect to database: {e}"],
+            )
+
+        # Collect worker and queue stats
+        workers = self._collect_worker_stats()
+        queue = self._collect_queue_stats()
+
+        # Determine health and collect warnings/errors
+        health, warnings, errors = self._determine_health(workers, queue, db_info)
+
+        return StatusInfo(
+            timestamp=timestamp,
+            health=health,
+            database=db_info,
+            workers=workers,
+            queue=queue,
+            warnings=warnings,
+            errors=errors,
+        )
+
+    def _collect_database_info(self) -> DatabaseInfo:
+        """Collect database metadata."""
+        path_str = str(self.db_path)
+
+        if not self.db_path.exists():
+            return DatabaseInfo(
+                path=path_str,
+                accessible=False,
+                exists=False,
+                error_message=f"Database not found: {path_str}",
+            )
+
+        try:
+            stat = self.db_path.stat()
+            return DatabaseInfo(
+                path=path_str,
+                accessible=True,
+                exists=True,
+                size_bytes=stat.st_size,
+                last_modified=datetime.fromtimestamp(stat.st_mtime),
+            )
+        except Exception as e:
+            logger.error(f"Error accessing database: {e}", exc_info=True)
+            return DatabaseInfo(
+                path=path_str,
+                accessible=False,
+                exists=True,
+                error_message=f"Cannot access database: {e}",
+            )
+
+    def _collect_worker_stats(self) -> Dict[str, WorkerTypeStats]:
+        """Collect worker statistics by type."""
+        if not self.job_queue:
+            return {}
+
+        try:
+            conn = self.job_queue._get_conn()
+
+            # Query workers grouped by type and status
+            result = {}
+            for worker_type in ["notebook", "plantuml", "drawio"]:
+                cursor = conn.execute(
+                    """
+                    SELECT status, COUNT(*) as count
+                    FROM workers
+                    WHERE worker_type = ?
+                    GROUP BY status
+                    """,
+                    (worker_type,),
+                )
+
+                status_counts = {row[0]: row[1] for row in cursor.fetchall()}
+
+                total = sum(status_counts.values())
+                idle = status_counts.get("idle", 0)
+                busy = status_counts.get("busy", 0)
+                hung = status_counts.get("hung", 0)
+                dead = status_counts.get("dead", 0)
+
+                # Get busy workers details
+                busy_workers = self._get_busy_workers(worker_type)
+
+                # Determine execution mode
+                execution_mode = self._get_worker_execution_mode(worker_type)
+
+                result[worker_type] = WorkerTypeStats(
+                    worker_type=worker_type,
+                    execution_mode=execution_mode,
+                    total=total,
+                    idle=idle,
+                    busy=busy,
+                    hung=hung,
+                    dead=dead,
+                    busy_workers=busy_workers,
+                )
+
+            return result
+
+        except Exception as e:
+            logger.error(f"Error collecting worker stats: {e}", exc_info=True)
+            return {}
+
+    def _get_busy_workers(self, worker_type: str) -> List[BusyWorkerInfo]:
+        """Get details of busy workers for a type."""
+        if not self.job_queue:
+            return []
+
+        try:
+            conn = self.job_queue._get_conn()
+            cursor = conn.execute(
+                """
+                SELECT
+                    w.container_id,
+                    j.id,
+                    j.input_file,
+                    CAST((julianday('now') - julianday(j.started_at)) * 86400 AS INTEGER) as elapsed
+                FROM workers w
+                JOIN jobs j ON j.worker_id = w.id
+                WHERE w.worker_type = ?
+                  AND w.status = 'busy'
+                  AND j.status = 'processing'
+                ORDER BY j.started_at ASC
+                """,
+                (worker_type,),
+            )
+
+            busy_workers = []
+            for row in cursor.fetchall():
+                busy_workers.append(
+                    BusyWorkerInfo(
+                        worker_id=row[0],
+                        job_id=str(row[1]),
+                        document_path=row[2],
+                        elapsed_seconds=row[3] or 0,
+                    )
+                )
+
+            return busy_workers
+
+        except Exception as e:
+            logger.error(f"Error getting busy workers: {e}", exc_info=True)
+            return []
+
+    def _get_worker_execution_mode(self, worker_type: str) -> Optional[str]:
+        """Get execution mode for worker type."""
+        if not self.job_queue:
+            return None
+
+        try:
+            conn = self.job_queue._get_conn()
+            cursor = conn.execute(
+                """
+                SELECT DISTINCT execution_mode
+                FROM workers
+                WHERE worker_type = ?
+                  AND status != 'dead'
+                """,
+                (worker_type,),
+            )
+
+            modes = [row[0] for row in cursor.fetchall() if row[0]]
+
+            if not modes:
+                return None
+            elif len(modes) == 1:
+                return modes[0]
+            else:
+                return "mixed"
+
+        except Exception:
+            return None
+
+    def _collect_queue_stats(self) -> QueueStats:
+        """Collect job queue statistics."""
+        if not self.job_queue:
+            return QueueStats(0, 0, 0, 0, None)
+
+        try:
+            conn = self.job_queue._get_conn()
+
+            # Get counts by status
+            cursor = conn.execute(
+                """
+                SELECT status, COUNT(*) as count
+                FROM jobs
+                WHERE status IN ('pending', 'processing')
+                GROUP BY status
+                """
+            )
+
+            counts = {row[0]: row[1] for row in cursor.fetchall()}
+            pending = counts.get("pending", 0)
+            processing = counts.get("processing", 0)
+
+            # Calculate oldest pending job
+            oldest_pending_seconds = None
+            if pending > 0:
+                cursor = conn.execute(
+                    """
+                    SELECT CAST((julianday('now') - julianday(created_at)) * 86400 AS INTEGER)
+                    FROM jobs
+                    WHERE status = 'pending'
+                    ORDER BY created_at ASC
+                    LIMIT 1
+                    """
+                )
+                row = cursor.fetchone()
+                if row:
+                    oldest_pending_seconds = row[0]
+
+            # Get completed/failed in last hour
+            one_hour_ago = datetime.now() - timedelta(hours=1)
+
+            cursor = conn.execute(
+                """
+                SELECT COUNT(*)
+                FROM jobs
+                WHERE status = 'completed'
+                  AND completed_at > ?
+                """,
+                (one_hour_ago.isoformat(),),
+            )
+            completed_last_hour = cursor.fetchone()[0]
+
+            cursor = conn.execute(
+                """
+                SELECT COUNT(*)
+                FROM jobs
+                WHERE status = 'failed'
+                  AND completed_at > ?
+                """,
+                (one_hour_ago.isoformat(),),
+            )
+            failed_last_hour = cursor.fetchone()[0]
+
+            return QueueStats(
+                pending=pending,
+                processing=processing,
+                completed_last_hour=completed_last_hour,
+                failed_last_hour=failed_last_hour,
+                oldest_pending_seconds=oldest_pending_seconds,
+            )
+
+        except Exception as e:
+            logger.error(f"Error collecting queue stats: {e}", exc_info=True)
+            return QueueStats(0, 0, 0, 0, None)
+
+    def _determine_health(
+        self,
+        workers: Dict[str, WorkerTypeStats],
+        queue: QueueStats,
+        db_info: DatabaseInfo,
+    ) -> tuple[SystemHealth, list[str], list[str]]:
+        """Determine system health and collect warnings/errors.
+
+        Returns:
+            Tuple of (health, warnings, errors)
+        """
+        warnings = []
+        errors = []
+
+        # Check database
+        if not db_info.accessible:
+            errors.append("Database not accessible")
+            return SystemHealth.ERROR, warnings, errors
+
+        # Check for workers
+        total_workers = sum(stats.total for stats in workers.values())
+        if total_workers == 0:
+            errors.append("No workers registered")
+            return SystemHealth.ERROR, warnings, errors
+
+        # Check for hung workers
+        hung_workers = sum(stats.hung for stats in workers.values())
+        if hung_workers > 0:
+            warnings.append(f"{hung_workers} worker(s) hung (processing > 5 minutes)")
+
+        # Check for dead workers
+        dead_workers = sum(stats.dead for stats in workers.values())
+        if dead_workers > 0:
+            warnings.append(f"{dead_workers} worker(s) dead (no heartbeat)")
+
+        # Check queue
+        if queue.pending > self.LONG_QUEUE_THRESHOLD:
+            idle_workers = sum(stats.idle for stats in workers.values())
+            if idle_workers == 0:
+                warnings.append(
+                    f"{queue.pending} jobs pending with no idle workers available"
+                )
+            else:
+                warnings.append(f"{queue.pending} jobs pending")
+
+        # Check oldest pending job
+        if (
+            queue.oldest_pending_seconds
+            and queue.oldest_pending_seconds > self.OLD_PENDING_JOB_THRESHOLD_SECONDS
+        ):
+            minutes = queue.oldest_pending_seconds // 60
+            warnings.append(f"Oldest pending job waiting {minutes} minutes")
+
+        # Check failure rate
+        total_recent_jobs = queue.completed_last_hour + queue.failed_last_hour
+        if total_recent_jobs > 0:
+            failure_rate = queue.failed_last_hour / total_recent_jobs
+            if failure_rate > 0.2:  # > 20% failure
+                warnings.append(
+                    f"High failure rate: {failure_rate:.1%} ({queue.failed_last_hour}/{total_recent_jobs} jobs)"
+                )
+
+        # Determine overall health
+        if errors:
+            return SystemHealth.ERROR, warnings, errors
+        elif warnings:
+            return SystemHealth.WARNING, warnings, errors
+        else:
+            return SystemHealth.HEALTHY, warnings, errors

--- a/src/clx/cli/status/formatter.py
+++ b/src/clx/cli/status/formatter.py
@@ -1,0 +1,37 @@
+"""Base formatter for status output."""
+
+from abc import ABC, abstractmethod
+
+from clx.cli.status.models import StatusInfo
+
+
+class StatusFormatter(ABC):
+    """Base class for status formatters."""
+
+    @abstractmethod
+    def format(
+        self, status: StatusInfo, workers_only: bool = False, jobs_only: bool = False
+    ) -> str:
+        """Format status information for output.
+
+        Args:
+            status: Status information to format
+            workers_only: Only show worker information
+            jobs_only: Only show job queue information
+
+        Returns:
+            Formatted string ready for output
+        """
+        pass
+
+    @abstractmethod
+    def get_exit_code(self, status: StatusInfo) -> int:
+        """Get appropriate exit code for status.
+
+        Args:
+            status: Status information
+
+        Returns:
+            Exit code (0=healthy, 1=warning, 2=error)
+        """
+        pass

--- a/src/clx/cli/status/formatters/__init__.py
+++ b/src/clx/cli/status/formatters/__init__.py
@@ -1,0 +1,7 @@
+"""Status formatters."""
+
+from clx.cli.status.formatters.compact_formatter import CompactFormatter
+from clx.cli.status.formatters.json_formatter import JsonFormatter
+from clx.cli.status.formatters.table_formatter import TableFormatter
+
+__all__ = ["CompactFormatter", "JsonFormatter", "TableFormatter"]

--- a/src/clx/cli/status/formatters/compact_formatter.py
+++ b/src/clx/cli/status/formatters/compact_formatter.py
@@ -1,0 +1,49 @@
+"""Compact single-line formatter."""
+
+from clx.cli.status.formatter import StatusFormatter
+from clx.cli.status.models import StatusInfo, SystemHealth
+
+
+class CompactFormatter(StatusFormatter):
+    """Format status as compact single line."""
+
+    def format(
+        self, status: StatusInfo, workers_only: bool = False, jobs_only: bool = False
+    ) -> str:
+        """Format status information as compact line."""
+        parts = []
+
+        # Health
+        parts.append(status.health.value)
+
+        if not jobs_only:
+            # Workers
+            worker_parts = []
+            for worker_type in ["notebook", "plantuml", "drawio"]:
+                stats = status.workers.get(worker_type)
+                if stats and stats.total > 0:
+                    worker_parts.append(
+                        f"{stats.total} {worker_type} ({stats.idle} idle, {stats.busy} busy)"
+                    )
+            if worker_parts:
+                parts.append(": " + ", ".join(worker_parts))
+
+        if not workers_only:
+            # Queue
+            queue_parts = []
+            if status.queue.pending > 0:
+                queue_parts.append(f"{status.queue.pending} pending")
+            if status.queue.processing > 0:
+                queue_parts.append(f"{status.queue.processing} processing")
+            if queue_parts:
+                parts.append(" | queue: " + ", ".join(queue_parts))
+
+        return "".join(parts)
+
+    def get_exit_code(self, status: StatusInfo) -> int:
+        """Get exit code based on health."""
+        return {
+            SystemHealth.HEALTHY: 0,
+            SystemHealth.WARNING: 1,
+            SystemHealth.ERROR: 2,
+        }[status.health]

--- a/src/clx/cli/status/formatters/json_formatter.py
+++ b/src/clx/cli/status/formatters/json_formatter.py
@@ -1,0 +1,103 @@
+"""JSON formatter for machine-readable output."""
+
+import json
+
+from clx.cli.status.formatter import StatusFormatter
+from clx.cli.status.models import StatusInfo, SystemHealth
+
+
+class JsonFormatter(StatusFormatter):
+    """Format status as JSON."""
+
+    def __init__(self, pretty: bool = True):
+        """Initialize formatter.
+
+        Args:
+            pretty: Whether to pretty-print JSON
+        """
+        self.pretty = pretty
+
+    def format(
+        self, status: StatusInfo, workers_only: bool = False, jobs_only: bool = False
+    ) -> str:
+        """Format status information as JSON."""
+        data = {
+            "status": status.health.value,
+            "timestamp": status.timestamp.isoformat(),
+        }
+
+        if not jobs_only:
+            # Database info
+            data["database"] = {
+                "path": status.database.path,
+                "accessible": status.database.accessible,
+                "exists": status.database.exists,
+            }
+            if status.database.size_bytes is not None:
+                data["database"]["size_bytes"] = status.database.size_bytes
+            if status.database.last_modified:
+                data["database"]["last_modified"] = (
+                    status.database.last_modified.isoformat()
+                )
+            if status.database.error_message:
+                data["database"]["error_message"] = status.database.error_message
+
+        if not jobs_only:
+            # Workers
+            data["workers"] = {}
+            for worker_type, stats in status.workers.items():
+                worker_data = {
+                    "total": stats.total,
+                    "idle": stats.idle,
+                    "busy": stats.busy,
+                    "hung": stats.hung,
+                    "dead": stats.dead,
+                }
+
+                if stats.execution_mode:
+                    worker_data["execution_mode"] = stats.execution_mode
+
+                if stats.busy_workers:
+                    worker_data["busy_workers"] = [
+                        {
+                            "worker_id": bw.worker_id,
+                            "job_id": bw.job_id,
+                            "document": bw.document_path,
+                            "elapsed_seconds": bw.elapsed_seconds,
+                        }
+                        for bw in stats.busy_workers
+                    ]
+
+                data["workers"][worker_type] = worker_data
+
+        if not workers_only:
+            # Queue
+            data["queue"] = {
+                "pending": status.queue.pending,
+                "processing": status.queue.processing,
+                "completed_last_hour": status.queue.completed_last_hour,
+                "failed_last_hour": status.queue.failed_last_hour,
+            }
+            if status.queue.oldest_pending_seconds is not None:
+                data["queue"]["oldest_pending_seconds"] = (
+                    status.queue.oldest_pending_seconds
+                )
+
+        # Issues
+        if status.warnings:
+            data["warnings"] = status.warnings
+        if status.errors:
+            data["errors"] = status.errors
+
+        if self.pretty:
+            return json.dumps(data, indent=2)
+        else:
+            return json.dumps(data)
+
+    def get_exit_code(self, status: StatusInfo) -> int:
+        """Get exit code based on health."""
+        return {
+            SystemHealth.HEALTHY: 0,
+            SystemHealth.WARNING: 1,
+            SystemHealth.ERROR: 2,
+        }[status.health]

--- a/src/clx/cli/status/formatters/table_formatter.py
+++ b/src/clx/cli/status/formatters/table_formatter.py
@@ -1,0 +1,238 @@
+"""Table formatter for human-readable output."""
+
+from datetime import datetime
+
+from clx.cli.status.formatter import StatusFormatter
+from clx.cli.status.models import StatusInfo, SystemHealth
+
+
+class TableFormatter(StatusFormatter):
+    """Format status as human-readable tables."""
+
+    def __init__(self, use_color: bool = True):
+        """Initialize formatter.
+
+        Args:
+            use_color: Whether to use colored output (ANSI codes)
+        """
+        self.use_color = use_color
+
+    def format(
+        self, status: StatusInfo, workers_only: bool = False, jobs_only: bool = False
+    ) -> str:
+        """Format status information as tables."""
+        lines = []
+
+        if not workers_only and not jobs_only:
+            # Show header
+            lines.extend(self._format_header(status))
+            lines.append("")
+
+        if not jobs_only:
+            # Show workers
+            lines.extend(self._format_workers(status))
+            lines.append("")
+
+        if not workers_only:
+            # Show queue
+            lines.extend(self._format_queue(status))
+            lines.append("")
+
+        if not workers_only and not jobs_only:
+            # Show warnings/errors
+            lines.extend(self._format_issues(status))
+
+        return "\n".join(lines)
+
+    def _format_header(self, status: StatusInfo) -> list[str]:
+        """Format header with system status."""
+        health_icon = {
+            SystemHealth.HEALTHY: "✓",
+            SystemHealth.WARNING: "⚠",
+            SystemHealth.ERROR: "✗",
+        }[status.health]
+
+        health_text = f"{health_icon} {status.health.value.title()}"
+
+        if self.use_color:
+            health_color = {
+                SystemHealth.HEALTHY: "\033[32m",  # Green
+                SystemHealth.WARNING: "\033[33m",  # Yellow
+                SystemHealth.ERROR: "\033[31m",  # Red
+            }[status.health]
+            reset = "\033[0m"
+            health_text = f"{health_color}{health_text}{reset}"
+
+        # Calculate time since last update
+        seconds_ago = (datetime.now() - status.timestamp).total_seconds()
+        if seconds_ago < 2:
+            update_str = "just now"
+        elif seconds_ago < 60:
+            update_str = f"{int(seconds_ago)}s ago"
+        else:
+            minutes = int(seconds_ago / 60)
+            update_str = f"{minutes}m ago"
+
+        # Get database size
+        if status.database.size_bytes:
+            size_kb = status.database.size_bytes / 1024
+            db_size = f"({size_kb:.0f} KB)"
+        else:
+            db_size = ""
+
+        lines = [
+            "=" * 70,
+            "CLX System Status",
+            "=" * 70,
+            f"Overall Status: {health_text}",
+            f"Database: {status.database.path} {db_size}",
+            f"Last Updated: {update_str}",
+        ]
+
+        return lines
+
+    def _format_workers(self, status: StatusInfo) -> list[str]:
+        """Format workers section."""
+        lines = ["Workers by Type"]
+        lines.append("-" * 70)
+
+        for worker_type in ["notebook", "plantuml", "drawio"]:
+            stats = status.workers.get(worker_type)
+            if stats is None:
+                continue
+
+            # Worker type header
+            mode_str = f" ({stats.execution_mode} mode)" if stats.execution_mode else ""
+            lines.append(
+                f"{worker_type.title()} Workers: {stats.total} total{mode_str}"
+            )
+
+            if stats.total == 0:
+                warning = "⚠ No workers registered"
+                if self.use_color:
+                    warning = f"\033[33m{warning}\033[0m"  # Yellow
+                lines.append(f"  {warning}")
+                lines.append("")
+                continue
+
+            # Status breakdown
+            if stats.idle > 0:
+                idle_text = f"✓ {stats.idle} idle"
+                if self.use_color:
+                    idle_text = f"\033[32m{idle_text}\033[0m"  # Green
+                lines.append(f"  {idle_text}")
+
+            if stats.busy > 0:
+                busy_text = f"⚙ {stats.busy} busy"
+                if self.use_color:
+                    busy_text = f"\033[34m{busy_text}\033[0m"  # Blue
+                lines.append(f"  {busy_text}")
+
+                # Show busy worker details
+                for bw in stats.busy_workers:
+                    elapsed_str = self._format_elapsed(bw.elapsed_seconds)
+                    # Truncate document path if too long
+                    doc_path = bw.document_path
+                    if len(doc_path) > 50:
+                        doc_path = "..." + doc_path[-47:]
+
+                    lines.append(
+                        f"     Worker {bw.worker_id[:12]}: {doc_path} ({elapsed_str})"
+                    )
+
+            if stats.hung > 0:
+                hung_text = f"⚠ {stats.hung} hung"
+                if self.use_color:
+                    hung_text = f"\033[33m{hung_text}\033[0m"  # Yellow
+                lines.append(f"  {hung_text}")
+
+            if stats.dead > 0:
+                dead_text = f"✗ {stats.dead} dead"
+                if self.use_color:
+                    dead_text = f"\033[31m{dead_text}\033[0m"  # Red
+                lines.append(f"  {dead_text}")
+
+            lines.append("")
+
+        return lines
+
+    def _format_queue(self, status: StatusInfo) -> list[str]:
+        """Format queue statistics."""
+        lines = ["Job Queue Status"]
+        lines.append("-" * 70)
+
+        queue = status.queue
+
+        # Pending jobs
+        pending_str = f"Pending:    {queue.pending} jobs"
+        if queue.oldest_pending_seconds:
+            oldest_str = self._format_elapsed(queue.oldest_pending_seconds)
+            pending_str += f"  (oldest: {oldest_str})"
+            if queue.oldest_pending_seconds > 300:  # 5 minutes
+                if self.use_color:
+                    pending_str = f"\033[33m{pending_str} ⚠\033[0m"  # Yellow
+                else:
+                    pending_str += " ⚠"
+
+        lines.append(f"  {pending_str}")
+
+        # Processing jobs
+        lines.append(f"  Processing: {queue.processing} jobs")
+
+        # Completed jobs
+        lines.append(f"  Completed:  {queue.completed_last_hour} jobs (last hour)")
+
+        # Failed jobs
+        total_recent = queue.completed_last_hour + queue.failed_last_hour
+        failure_str = f"  Failed:     {queue.failed_last_hour} jobs"
+        if total_recent > 0:
+            failure_rate = queue.failed_last_hour / total_recent
+            failure_str += f"  ({failure_rate:.1%} failure rate)"
+            if failure_rate > 0.2:
+                if self.use_color:
+                    failure_str = f"\033[31m{failure_str}\033[0m"  # Red
+
+        lines.append(failure_str)
+
+        return lines
+
+    def _format_issues(self, status: StatusInfo) -> list[str]:
+        """Format warnings and errors."""
+        lines = []
+
+        if status.errors:
+            for error in status.errors:
+                error_text = f"✗ Error: {error}"
+                if self.use_color:
+                    error_text = f"\033[31m{error_text}\033[0m"  # Red
+                lines.append(error_text)
+
+        if status.warnings:
+            for warning in status.warnings:
+                warning_text = f"⚠ Warning: {warning}"
+                if self.use_color:
+                    warning_text = f"\033[33m{warning_text}\033[0m"  # Yellow
+                lines.append(warning_text)
+
+        return lines
+
+    def _format_elapsed(self, seconds: int) -> str:
+        """Format elapsed time."""
+        if seconds < 60:
+            return f"{seconds}s"
+        elif seconds < 3600:
+            minutes = seconds // 60
+            secs = seconds % 60
+            return f"{minutes}:{secs:02d}"
+        else:
+            hours = seconds // 3600
+            minutes = (seconds % 3600) // 60
+            return f"{hours}:{minutes:02d}:{seconds % 60:02d}"
+
+    def get_exit_code(self, status: StatusInfo) -> int:
+        """Get exit code based on health."""
+        return {
+            SystemHealth.HEALTHY: 0,
+            SystemHealth.WARNING: 1,
+            SystemHealth.ERROR: 2,
+        }[status.health]

--- a/src/clx/cli/status/models.py
+++ b/src/clx/cli/status/models.py
@@ -1,0 +1,83 @@
+"""Data models for status information."""
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from typing import Dict, List, Optional
+
+
+class SystemHealth(Enum):
+    """Overall system health status."""
+
+    HEALTHY = "healthy"
+    WARNING = "warning"
+    ERROR = "error"
+
+
+class WorkerStatus(Enum):
+    """Worker status."""
+
+    IDLE = "idle"
+    BUSY = "busy"
+    HUNG = "hung"
+    DEAD = "dead"
+
+
+@dataclass
+class DatabaseInfo:
+    """Database connectivity and metadata."""
+
+    path: str
+    accessible: bool
+    exists: bool
+    size_bytes: Optional[int] = None
+    last_modified: Optional[datetime] = None
+    error_message: Optional[str] = None
+
+
+@dataclass
+class BusyWorkerInfo:
+    """Information about a busy worker."""
+
+    worker_id: str
+    job_id: str
+    document_path: str
+    elapsed_seconds: int
+
+
+@dataclass
+class WorkerTypeStats:
+    """Statistics for a specific worker type."""
+
+    worker_type: str  # notebook, plantuml, drawio
+    execution_mode: Optional[str]  # direct, docker, or mixed
+    total: int
+    idle: int
+    busy: int
+    hung: int
+    dead: int
+    busy_workers: List[BusyWorkerInfo] = field(default_factory=list)
+
+
+@dataclass
+class QueueStats:
+    """Job queue statistics."""
+
+    pending: int
+    processing: int
+    completed_last_hour: int
+    failed_last_hour: int
+    oldest_pending_seconds: Optional[int] = None
+
+
+@dataclass
+class StatusInfo:
+    """Complete system status information."""
+
+    timestamp: datetime
+    health: SystemHealth
+    database: DatabaseInfo
+    workers: Dict[str, WorkerTypeStats]  # key: worker_type
+    queue: QueueStats
+    warnings: List[str] = field(default_factory=list)
+    errors: List[str] = field(default_factory=list)

--- a/src/clx/infrastructure/database/schema.py
+++ b/src/clx/infrastructure/database/schema.py
@@ -70,7 +70,13 @@ CREATE TABLE IF NOT EXISTS workers (
 
     jobs_processed INTEGER DEFAULT 0,
     jobs_failed INTEGER DEFAULT 0,
-    avg_processing_time REAL
+    avg_processing_time REAL,
+
+    -- v3 schema additions
+    execution_mode TEXT,
+    config TEXT,
+    session_id TEXT,
+    managed_by TEXT
 );
 
 CREATE INDEX IF NOT EXISTS idx_workers_status ON workers(worker_type, status);

--- a/tests/cli/test_status_collector.py
+++ b/tests/cli/test_status_collector.py
@@ -1,0 +1,266 @@
+"""Tests for StatusCollector class."""
+
+import pytest
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from clx.cli.status.collector import StatusCollector
+from clx.cli.status.models import SystemHealth
+from clx.infrastructure.database.job_queue import JobQueue
+from clx.infrastructure.database.schema import init_database
+
+
+class TestStatusCollector:
+    """Test StatusCollector with real database."""
+
+    @pytest.fixture
+    def db_path(self, tmp_path):
+        """Create temporary database."""
+        db_path = tmp_path / "test_status.db"
+        init_database(db_path)
+        return db_path
+
+    @pytest.fixture
+    def job_queue(self, db_path):
+        """Create JobQueue instance."""
+        return JobQueue(db_path)
+
+    def test_collect_database_not_found(self, tmp_path):
+        """Test collecting status when database doesn't exist."""
+        db_path = tmp_path / "nonexistent.db"
+        collector = StatusCollector(db_path=db_path)
+
+        status = collector.collect()
+
+        assert status.health == SystemHealth.ERROR
+        assert not status.database.accessible
+        assert not status.database.exists
+        assert "not found" in status.database.error_message.lower()
+
+    def test_collect_empty_database(self, db_path):
+        """Test collecting status from empty database."""
+        collector = StatusCollector(db_path=db_path)
+
+        status = collector.collect()
+
+        # Should be error since no workers are registered
+        assert status.health == SystemHealth.ERROR
+        assert status.database.accessible
+        assert status.database.exists
+        assert "No workers registered" in status.errors
+
+    def test_collect_with_idle_workers(self, db_path, job_queue):
+        """Test collecting status with idle workers."""
+        # Register workers
+        conn = job_queue._get_conn()
+        conn.execute(
+            """
+            INSERT INTO workers (worker_type, container_id, status, execution_mode)
+            VALUES ('notebook', 'nb-worker-1', 'idle', 'direct')
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO workers (worker_type, container_id, status, execution_mode)
+            VALUES ('plantuml', 'pu-worker-1', 'idle', 'docker')
+            """
+        )
+        conn.commit()
+
+        collector = StatusCollector(db_path=db_path)
+        status = collector.collect()
+
+        # Should be healthy
+        assert status.health == SystemHealth.HEALTHY
+        assert status.workers["notebook"].total == 1
+        assert status.workers["notebook"].idle == 1
+        assert status.workers["notebook"].execution_mode == "direct"
+        assert status.workers["plantuml"].total == 1
+        assert status.workers["plantuml"].execution_mode == "docker"
+
+    def test_collect_with_busy_workers(self, db_path, job_queue):
+        """Test collecting status with busy workers processing jobs."""
+        # Register worker
+        conn = job_queue._get_conn()
+        cursor = conn.execute(
+            """
+            INSERT INTO workers (worker_type, container_id, status, execution_mode)
+            VALUES ('notebook', 'nb-worker-1', 'busy', 'direct')
+            """
+        )
+        worker_id = cursor.lastrowid
+
+        # Create a job
+        job_id = job_queue.add_job(
+            job_type="notebook",
+            input_file="/path/to/input.ipynb",
+            output_file="/path/to/output.html",
+            content_hash="abc123",
+            payload={"test": "data"},
+        )
+
+        # Mark job as processing
+        conn.execute(
+            """
+            UPDATE jobs
+            SET status = 'processing', worker_id = ?, started_at = ?
+            WHERE id = ?
+            """,
+            (worker_id, datetime.now().isoformat(), job_id),
+        )
+        conn.commit()
+
+        collector = StatusCollector(db_path=db_path)
+        status = collector.collect()
+
+        assert status.health == SystemHealth.HEALTHY
+        assert status.workers["notebook"].busy == 1
+        assert len(status.workers["notebook"].busy_workers) == 1
+        assert status.workers["notebook"].busy_workers[0].document_path == "/path/to/input.ipynb"
+
+    def test_collect_with_pending_jobs(self, db_path, job_queue):
+        """Test collecting status with pending jobs."""
+        # Register worker
+        conn = job_queue._get_conn()
+        conn.execute(
+            """
+            INSERT INTO workers (worker_type, container_id, status, execution_mode)
+            VALUES ('notebook', 'nb-worker-1', 'idle', 'direct')
+            """
+        )
+        conn.commit()
+
+        # Add pending jobs
+        for i in range(15):
+            job_queue.add_job(
+                job_type="notebook",
+                input_file=f"/path/to/input{i}.ipynb",
+                output_file=f"/path/to/output{i}.html",
+                content_hash=f"hash{i}",
+                payload={"test": "data"},
+            )
+
+        collector = StatusCollector(db_path=db_path)
+        status = collector.collect()
+
+        # Should be warning due to high pending jobs
+        assert status.health == SystemHealth.WARNING
+        assert status.queue.pending == 15
+        assert any("15 jobs pending" in w for w in status.warnings)
+
+    def test_collect_queue_stats(self, db_path, job_queue):
+        """Test collecting queue statistics."""
+        # Register worker
+        conn = job_queue._get_conn()
+        conn.execute(
+            """
+            INSERT INTO workers (worker_type, container_id, status, execution_mode)
+            VALUES ('notebook', 'nb-worker-1', 'idle', 'direct')
+            """
+        )
+        conn.commit()
+
+        # Add jobs with different statuses
+        # Pending
+        for i in range(3):
+            job_queue.add_job(
+                job_type="notebook",
+                input_file=f"/path/to/pending{i}.ipynb",
+                output_file=f"/path/to/pending{i}.html",
+                content_hash=f"pending{i}",
+                payload={},
+            )
+
+        # Completed in last hour
+        one_hour_ago = datetime.now() - timedelta(minutes=30)
+        for i in range(5):
+            job_id = job_queue.add_job(
+                job_type="notebook",
+                input_file=f"/path/to/completed{i}.ipynb",
+                output_file=f"/path/to/completed{i}.html",
+                content_hash=f"completed{i}",
+                payload={},
+            )
+            conn.execute(
+                """
+                UPDATE jobs
+                SET status = 'completed', completed_at = ?
+                WHERE id = ?
+                """,
+                (one_hour_ago.isoformat(), job_id),
+            )
+
+        # Failed in last hour
+        for i in range(2):
+            job_id = job_queue.add_job(
+                job_type="notebook",
+                input_file=f"/path/to/failed{i}.ipynb",
+                output_file=f"/path/to/failed{i}.html",
+                content_hash=f"failed{i}",
+                payload={},
+            )
+            conn.execute(
+                """
+                UPDATE jobs
+                SET status = 'failed', completed_at = ?, error = 'Test error'
+                WHERE id = ?
+                """,
+                (one_hour_ago.isoformat(), job_id),
+            )
+
+        conn.commit()
+
+        collector = StatusCollector(db_path=db_path)
+        status = collector.collect()
+
+        assert status.queue.pending == 3
+        assert status.queue.completed_last_hour == 5
+        assert status.queue.failed_last_hour == 2
+
+    def test_collect_mixed_execution_modes(self, db_path, job_queue):
+        """Test collecting status with mixed execution modes."""
+        # Register workers with different execution modes
+        conn = job_queue._get_conn()
+        conn.execute(
+            """
+            INSERT INTO workers (worker_type, container_id, status, execution_mode)
+            VALUES ('notebook', 'nb-worker-1', 'idle', 'direct')
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO workers (worker_type, container_id, status, execution_mode)
+            VALUES ('notebook', 'nb-worker-2', 'idle', 'docker')
+            """
+        )
+        conn.commit()
+
+        collector = StatusCollector(db_path=db_path)
+        status = collector.collect()
+
+        assert status.workers["notebook"].execution_mode == "mixed"
+
+    def test_collect_database_info(self, db_path):
+        """Test collecting database metadata."""
+        collector = StatusCollector(db_path=db_path)
+        status = collector.collect()
+
+        assert status.database.path == str(db_path)
+        assert status.database.accessible
+        assert status.database.exists
+        assert status.database.size_bytes is not None
+        assert status.database.size_bytes > 0
+        assert status.database.last_modified is not None
+
+    def test_default_db_path_detection(self, tmp_path, monkeypatch):
+        """Test default database path detection."""
+        # Change to temp directory
+        monkeypatch.chdir(tmp_path)
+
+        # Create database in current directory
+        db_path = tmp_path / "clx_jobs.db"
+        init_database(db_path)
+
+        # Collector should find it automatically
+        collector = StatusCollector()
+        assert collector.db_path == db_path

--- a/tests/cli/test_status_integration.py
+++ b/tests/cli/test_status_integration.py
@@ -1,0 +1,220 @@
+"""Integration tests for status command."""
+
+import json
+
+import pytest
+from click.testing import CliRunner
+from pathlib import Path
+
+from clx.cli.main import cli
+from clx.infrastructure.database.job_queue import JobQueue
+from clx.infrastructure.database.schema import init_database
+
+
+@pytest.mark.integration
+class TestStatusCommandIntegration:
+    """Integration tests for status command with database."""
+
+    @pytest.fixture
+    def db_path(self, tmp_path):
+        """Create temporary database."""
+        db_path = tmp_path / "test_jobs.db"
+        init_database(db_path)
+        return db_path
+
+    @pytest.fixture
+    def job_queue(self, db_path):
+        """Create JobQueue instance."""
+        return JobQueue(db_path)
+
+    @pytest.fixture
+    def runner(self):
+        """Create Click test runner."""
+        return CliRunner()
+
+    def test_status_command_no_database(self, runner, tmp_path):
+        """Test status command when database doesn't exist."""
+        db_path = tmp_path / "nonexistent.db"
+
+        result = runner.invoke(cli, ["status", "--db-path", str(db_path)])
+
+        assert result.exit_code == 2  # Error
+        assert "not found" in result.output.lower() or "not accessible" in result.output.lower()
+
+    def test_status_command_empty_database(self, runner, db_path):
+        """Test status command with empty database."""
+        result = runner.invoke(cli, ["status", "--db-path", str(db_path)])
+
+        assert result.exit_code == 2  # Error
+        assert "no workers" in result.output.lower()
+
+    def test_status_command_with_workers(self, runner, db_path, job_queue):
+        """Test status command with registered workers."""
+        # Register workers
+        conn = job_queue._get_conn()
+        conn.execute(
+            """
+            INSERT INTO workers (worker_type, container_id, status, execution_mode)
+            VALUES ('notebook', 'nb-worker-1', 'idle', 'direct')
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO workers (worker_type, container_id, status, execution_mode)
+            VALUES ('plantuml', 'pu-worker-1', 'idle', 'docker')
+            """
+        )
+        conn.commit()
+
+        result = runner.invoke(cli, ["status", "--db-path", str(db_path)])
+
+        assert result.exit_code == 0  # Healthy
+        assert "notebook" in result.output.lower()
+        assert "plantuml" in result.output.lower()
+        assert "1 total" in result.output.lower()
+
+    def test_status_command_json_format(self, runner, db_path, job_queue):
+        """Test status command with JSON format."""
+        # Register a worker
+        conn = job_queue._get_conn()
+        conn.execute(
+            """
+            INSERT INTO workers (worker_type, container_id, status, execution_mode)
+            VALUES ('notebook', 'nb-worker-1', 'idle', 'direct')
+            """
+        )
+        conn.commit()
+
+        result = runner.invoke(cli, ["status", "--db-path", str(db_path), "--format=json"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert "status" in data
+        assert data["status"] == "healthy"
+        assert "workers" in data
+        assert "queue" in data
+        assert data["workers"]["notebook"]["total"] == 1
+
+    def test_status_command_compact_format(self, runner, db_path, job_queue):
+        """Test status command with compact format."""
+        # Register a worker
+        conn = job_queue._get_conn()
+        conn.execute(
+            """
+            INSERT INTO workers (worker_type, container_id, status, execution_mode)
+            VALUES ('notebook', 'nb-worker-1', 'idle', 'direct')
+            """
+        )
+        conn.commit()
+
+        result = runner.invoke(cli, ["status", "--db-path", str(db_path), "--format=compact"])
+
+        assert result.exit_code == 0
+        assert "healthy" in result.output
+        assert "notebook" in result.output
+
+    def test_status_command_workers_only(self, runner, db_path, job_queue):
+        """Test status command with --workers flag."""
+        # Register a worker
+        conn = job_queue._get_conn()
+        conn.execute(
+            """
+            INSERT INTO workers (worker_type, container_id, status, execution_mode)
+            VALUES ('notebook', 'nb-worker-1', 'idle', 'direct')
+            """
+        )
+        conn.commit()
+
+        result = runner.invoke(cli, ["status", "--db-path", str(db_path), "--workers"])
+
+        assert result.exit_code == 0
+        assert "notebook" in result.output.lower()
+        # Should not show queue status
+        assert "job queue" not in result.output.lower()
+
+    def test_status_command_jobs_only(self, runner, db_path, job_queue):
+        """Test status command with --jobs flag."""
+        # Register a worker
+        conn = job_queue._get_conn()
+        conn.execute(
+            """
+            INSERT INTO workers (worker_type, container_id, status, execution_mode)
+            VALUES ('notebook', 'nb-worker-1', 'idle', 'direct')
+            """
+        )
+        conn.commit()
+
+        # Add some jobs
+        for i in range(3):
+            job_queue.add_job(
+                job_type="notebook",
+                input_file=f"/path/to/input{i}.ipynb",
+                output_file=f"/path/to/output{i}.html",
+                content_hash=f"hash{i}",
+                payload={},
+            )
+
+        result = runner.invoke(cli, ["status", "--db-path", str(db_path), "--jobs"])
+
+        assert result.exit_code == 0
+        assert "job queue" in result.output.lower()
+        assert "pending" in result.output.lower()
+        # Should not show CLX System Status header
+        assert "clx system status" not in result.output.lower()
+
+    def test_status_command_no_color(self, runner, db_path, job_queue):
+        """Test status command with --no-color flag."""
+        # Register a worker
+        conn = job_queue._get_conn()
+        conn.execute(
+            """
+            INSERT INTO workers (worker_type, container_id, status, execution_mode)
+            VALUES ('notebook', 'nb-worker-1', 'idle', 'direct')
+            """
+        )
+        conn.commit()
+
+        result = runner.invoke(cli, ["status", "--db-path", str(db_path), "--no-color"])
+
+        assert result.exit_code == 0
+        # Check that there are no ANSI escape codes
+        assert "\033[" not in result.output
+
+    def test_status_command_with_pending_jobs(self, runner, db_path, job_queue):
+        """Test status command with many pending jobs."""
+        # Register a worker
+        conn = job_queue._get_conn()
+        conn.execute(
+            """
+            INSERT INTO workers (worker_type, container_id, status, execution_mode)
+            VALUES ('notebook', 'nb-worker-1', 'idle', 'direct')
+            """
+        )
+        conn.commit()
+
+        # Add many pending jobs (triggers warning)
+        for i in range(15):
+            job_queue.add_job(
+                job_type="notebook",
+                input_file=f"/path/to/input{i}.ipynb",
+                output_file=f"/path/to/output{i}.html",
+                content_hash=f"hash{i}",
+                payload={},
+            )
+
+        result = runner.invoke(cli, ["status", "--db-path", str(db_path)])
+
+        assert result.exit_code == 1  # Warning
+        assert "15" in result.output
+        assert "pending" in result.output.lower()
+
+    def test_status_command_help(self, runner):
+        """Test status command help text."""
+        result = runner.invoke(cli, ["status", "--help"])
+
+        assert result.exit_code == 0
+        assert "Show CLX system status" in result.output
+        assert "--workers" in result.output
+        assert "--jobs" in result.output
+        assert "--format" in result.output
+        assert "--db-path" in result.output

--- a/tests/cli/test_status_unit.py
+++ b/tests/cli/test_status_unit.py
@@ -1,0 +1,379 @@
+"""Unit tests for status command components."""
+
+import json
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from clx.cli.status.models import (
+    BusyWorkerInfo,
+    DatabaseInfo,
+    QueueStats,
+    StatusInfo,
+    SystemHealth,
+    WorkerTypeStats,
+)
+from clx.cli.status.formatters.compact_formatter import CompactFormatter
+from clx.cli.status.formatters.json_formatter import JsonFormatter
+from clx.cli.status.formatters.table_formatter import TableFormatter
+
+
+class TestModels:
+    """Test data models."""
+
+    def test_status_info_creation(self):
+        """Test creating StatusInfo object."""
+        status = StatusInfo(
+            timestamp=datetime(2025, 11, 15, 10, 30, 0),
+            health=SystemHealth.HEALTHY,
+            database=DatabaseInfo(
+                path="/path/to/db", accessible=True, exists=True, size_bytes=102400
+            ),
+            workers={
+                "notebook": WorkerTypeStats(
+                    worker_type="notebook",
+                    execution_mode="direct",
+                    total=2,
+                    idle=1,
+                    busy=1,
+                    hung=0,
+                    dead=0,
+                )
+            },
+            queue=QueueStats(
+                pending=5, processing=2, completed_last_hour=100, failed_last_hour=2
+            ),
+        )
+
+        assert status.health == SystemHealth.HEALTHY
+        assert status.database.path == "/path/to/db"
+        assert status.workers["notebook"].total == 2
+        assert status.queue.pending == 5
+
+    def test_worker_type_stats_with_busy_workers(self):
+        """Test WorkerTypeStats with busy workers."""
+        stats = WorkerTypeStats(
+            worker_type="notebook",
+            execution_mode="docker",
+            total=3,
+            idle=1,
+            busy=2,
+            hung=0,
+            dead=0,
+            busy_workers=[
+                BusyWorkerInfo(
+                    worker_id="worker-1",
+                    job_id="job-123",
+                    document_path="/path/to/doc.ipynb",
+                    elapsed_seconds=45,
+                ),
+                BusyWorkerInfo(
+                    worker_id="worker-2",
+                    job_id="job-456",
+                    document_path="/path/to/other.ipynb",
+                    elapsed_seconds=120,
+                ),
+            ],
+        )
+
+        assert stats.total == 3
+        assert stats.busy == 2
+        assert len(stats.busy_workers) == 2
+        assert stats.busy_workers[0].worker_id == "worker-1"
+
+
+class TestJsonFormatter:
+    """Test JSON formatter."""
+
+    def test_json_formatter_basic(self):
+        """Test JSON formatter with basic status."""
+        status = StatusInfo(
+            timestamp=datetime(2025, 11, 15, 10, 30, 0),
+            health=SystemHealth.HEALTHY,
+            database=DatabaseInfo(
+                path="/path/to/db", accessible=True, exists=True, size_bytes=102400
+            ),
+            workers={
+                "notebook": WorkerTypeStats(
+                    worker_type="notebook",
+                    execution_mode="direct",
+                    total=2,
+                    idle=1,
+                    busy=1,
+                    hung=0,
+                    dead=0,
+                )
+            },
+            queue=QueueStats(
+                pending=5, processing=2, completed_last_hour=100, failed_last_hour=2
+            ),
+        )
+
+        formatter = JsonFormatter(pretty=False)
+        output = formatter.format(status)
+
+        data = json.loads(output)
+
+        assert data["status"] == "healthy"
+        assert data["workers"]["notebook"]["total"] == 2
+        assert data["queue"]["pending"] == 5
+
+    def test_json_formatter_workers_only(self):
+        """Test JSON formatter with workers_only flag."""
+        status = StatusInfo(
+            timestamp=datetime.now(),
+            health=SystemHealth.HEALTHY,
+            database=DatabaseInfo(path="/path/to/db", accessible=True, exists=True),
+            workers={
+                "notebook": WorkerTypeStats(
+                    worker_type="notebook",
+                    execution_mode="direct",
+                    total=2,
+                    idle=1,
+                    busy=1,
+                    hung=0,
+                    dead=0,
+                )
+            },
+            queue=QueueStats(pending=5, processing=2, completed_last_hour=100, failed_last_hour=2),
+        )
+
+        formatter = JsonFormatter(pretty=False)
+        output = formatter.format(status, workers_only=True)
+
+        data = json.loads(output)
+
+        assert "workers" in data
+        assert "queue" not in data
+
+    def test_json_formatter_jobs_only(self):
+        """Test JSON formatter with jobs_only flag."""
+        status = StatusInfo(
+            timestamp=datetime.now(),
+            health=SystemHealth.HEALTHY,
+            database=DatabaseInfo(path="/path/to/db", accessible=True, exists=True),
+            workers={},
+            queue=QueueStats(pending=5, processing=2, completed_last_hour=100, failed_last_hour=2),
+        )
+
+        formatter = JsonFormatter(pretty=False)
+        output = formatter.format(status, jobs_only=True)
+
+        data = json.loads(output)
+
+        assert "queue" in data
+        assert "workers" not in data
+        assert "database" not in data
+
+    def test_json_formatter_exit_codes(self):
+        """Test exit codes for different health states."""
+        formatter = JsonFormatter()
+
+        healthy_status = StatusInfo(
+            timestamp=datetime.now(),
+            health=SystemHealth.HEALTHY,
+            database=DatabaseInfo(path="/path/to/db", accessible=True, exists=True),
+            workers={},
+            queue=QueueStats(0, 0, 0, 0),
+        )
+        assert formatter.get_exit_code(healthy_status) == 0
+
+        warning_status = StatusInfo(
+            timestamp=datetime.now(),
+            health=SystemHealth.WARNING,
+            database=DatabaseInfo(path="/path/to/db", accessible=True, exists=True),
+            workers={},
+            queue=QueueStats(0, 0, 0, 0),
+            warnings=["Something"],
+        )
+        assert formatter.get_exit_code(warning_status) == 1
+
+        error_status = StatusInfo(
+            timestamp=datetime.now(),
+            health=SystemHealth.ERROR,
+            database=DatabaseInfo(path="/path/to/db", accessible=True, exists=True),
+            workers={},
+            queue=QueueStats(0, 0, 0, 0),
+            errors=["Database error"],
+        )
+        assert formatter.get_exit_code(error_status) == 2
+
+
+class TestCompactFormatter:
+    """Test compact formatter."""
+
+    def test_compact_formatter(self):
+        """Test compact formatter output."""
+        status = StatusInfo(
+            timestamp=datetime.now(),
+            health=SystemHealth.WARNING,
+            database=DatabaseInfo(path="/path/to/db", accessible=True, exists=True),
+            workers={
+                "notebook": WorkerTypeStats(
+                    worker_type="notebook",
+                    execution_mode="direct",
+                    total=2,
+                    idle=0,
+                    busy=2,
+                    hung=0,
+                    dead=0,
+                )
+            },
+            queue=QueueStats(
+                pending=10,
+                processing=2,
+                completed_last_hour=50,
+                failed_last_hour=5,
+            ),
+            warnings=["High queue depth"],
+        )
+
+        formatter = CompactFormatter()
+        output = formatter.format(status)
+
+        assert "warning" in output
+        assert "2 notebook" in output
+        assert "10 pending" in output
+
+    def test_compact_formatter_healthy(self):
+        """Test compact formatter with healthy status."""
+        status = StatusInfo(
+            timestamp=datetime.now(),
+            health=SystemHealth.HEALTHY,
+            database=DatabaseInfo(path="/path/to/db", accessible=True, exists=True),
+            workers={
+                "notebook": WorkerTypeStats(
+                    worker_type="notebook",
+                    execution_mode="direct",
+                    total=2,
+                    idle=2,
+                    busy=0,
+                    hung=0,
+                    dead=0,
+                )
+            },
+            queue=QueueStats(
+                pending=0,
+                processing=0,
+                completed_last_hour=50,
+                failed_last_hour=0,
+            ),
+        )
+
+        formatter = CompactFormatter()
+        output = formatter.format(status)
+
+        assert "healthy" in output
+        assert "2 notebook (2 idle, 0 busy)" in output
+
+
+class TestTableFormatter:
+    """Test table formatter."""
+
+    def test_table_formatter_basic(self):
+        """Test table formatter with basic status."""
+        status = StatusInfo(
+            timestamp=datetime.now(),
+            health=SystemHealth.HEALTHY,
+            database=DatabaseInfo(
+                path="/path/to/db", accessible=True, exists=True, size_bytes=102400
+            ),
+            workers={
+                "notebook": WorkerTypeStats(
+                    worker_type="notebook",
+                    execution_mode="direct",
+                    total=2,
+                    idle=1,
+                    busy=1,
+                    hung=0,
+                    dead=0,
+                )
+            },
+            queue=QueueStats(
+                pending=5, processing=2, completed_last_hour=100, failed_last_hour=2
+            ),
+        )
+
+        formatter = TableFormatter(use_color=False)
+        output = formatter.format(status)
+
+        assert "CLX System Status" in output
+        assert "Notebook Workers: 2 total" in output
+        assert "Pending:    5 jobs" in output
+
+    def test_table_formatter_no_workers(self):
+        """Test table formatter with no workers."""
+        status = StatusInfo(
+            timestamp=datetime.now(),
+            health=SystemHealth.ERROR,
+            database=DatabaseInfo(path="/path/to/db", accessible=True, exists=True),
+            workers={
+                "notebook": WorkerTypeStats(
+                    worker_type="notebook",
+                    execution_mode=None,
+                    total=0,
+                    idle=0,
+                    busy=0,
+                    hung=0,
+                    dead=0,
+                )
+            },
+            queue=QueueStats(pending=0, processing=0, completed_last_hour=0, failed_last_hour=0),
+            errors=["No workers registered"],
+        )
+
+        formatter = TableFormatter(use_color=False)
+        output = formatter.format(status)
+
+        assert "No workers registered" in output
+
+    def test_table_formatter_workers_only(self):
+        """Test table formatter with workers_only flag."""
+        status = StatusInfo(
+            timestamp=datetime.now(),
+            health=SystemHealth.HEALTHY,
+            database=DatabaseInfo(path="/path/to/db", accessible=True, exists=True),
+            workers={
+                "notebook": WorkerTypeStats(
+                    worker_type="notebook",
+                    execution_mode="direct",
+                    total=2,
+                    idle=2,
+                    busy=0,
+                    hung=0,
+                    dead=0,
+                )
+            },
+            queue=QueueStats(pending=0, processing=0, completed_last_hour=0, failed_last_hour=0),
+        )
+
+        formatter = TableFormatter(use_color=False)
+        output = formatter.format(status, workers_only=True)
+
+        assert "Notebook Workers" in output
+        assert "Job Queue Status" not in output
+
+    def test_table_formatter_jobs_only(self):
+        """Test table formatter with jobs_only flag."""
+        status = StatusInfo(
+            timestamp=datetime.now(),
+            health=SystemHealth.HEALTHY,
+            database=DatabaseInfo(path="/path/to/db", accessible=True, exists=True),
+            workers={},
+            queue=QueueStats(pending=5, processing=2, completed_last_hour=100, failed_last_hour=2),
+        )
+
+        formatter = TableFormatter(use_color=False)
+        output = formatter.format(status, jobs_only=True)
+
+        assert "Job Queue Status" in output
+        assert "Workers by Type" not in output
+
+    def test_table_formatter_elapsed_time_format(self):
+        """Test elapsed time formatting."""
+        formatter = TableFormatter(use_color=False)
+
+        assert formatter._format_elapsed(30) == "30s"
+        assert formatter._format_elapsed(90) == "1:30"
+        assert formatter._format_elapsed(3661) == "1:01:01"


### PR DESCRIPTION
Add comprehensive status command to the CLX CLI that provides snapshot view of system state including worker availability, job queue status, and system health indicators.

Features:
- Status collection from SQLite database
- Multiple output formats (table, JSON, compact)
- Filtering options (--workers, --jobs)
- Health-based exit codes (0=healthy, 1=warning, 2=error)
- Colored output support with --no-color option
- Automatic database path detection

Implementation:
- StatusCollector: Queries database for worker and job statistics
- Three formatters: TableFormatter, JsonFormatter, CompactFormatter
- Data models for type-safe status information
- Integration with existing JobQueue infrastructure

Database schema update:
- Add execution_mode, config, session_id, managed_by columns to workers table in initial schema to match v3 migration

Tests:
- 13 unit tests for models and formatters
- 9 unit tests for StatusCollector
- 10 integration tests for CLI command
- All existing tests continue to pass (237 tests)

Addresses requirements in:
- .claude/requirements/cli_status_command_requirements.md
- .claude/design/cli_status_command_design.md