### PR TITLE
Document installation of dependencies for tests in CLAUDE.md

### DIFF
--- a/.claude/SETUP_SCRIPT_README.md
+++ b/.claude/SETUP_SCRIPT_README.md
@@ -1,0 +1,134 @@
+# CLX Test Environment Setup Script
+
+This directory contains `setup-test-env.sh`, an automated script for setting up a complete development and testing environment for the CLX project.
+
+## Purpose
+
+The setup script was created to solve the problem of manual environment setup in Claude Code on the web and other remote/headless environments. Previously, setting up the environment required running many manual steps, which was error-prone and time-consuming.
+
+## What It Does
+
+The script automates:
+
+1. **Package Installation**: Installs CLX with all dependencies (`[all]` extras) including test, TUI, and web dependencies
+2. **Service Installation**: Installs all three worker service packages (notebook-processor, plantuml-converter, drawio-converter)
+3. **PlantUML Setup**: Downloads PlantUML JAR from GitHub releases and creates wrapper script
+4. **DrawIO Setup**: Downloads DrawIO Debian package and extracts the binary
+5. **Xvfb Setup**: Starts Xvfb for headless rendering required by DrawIO
+6. **Environment Variables**: Sets and persists PLANTUML_JAR, DISPLAY, and DRAWIO_EXECUTABLE
+7. **Verification**: Verifies all components are working correctly
+
+## Usage
+
+### Basic Usage
+
+```bash
+# From CLX repository root
+./.claude/setup-test-env.sh
+```
+
+### Options
+
+```bash
+# Skip verification at the end (faster, but won't check if everything works)
+./.claude/setup-test-env.sh --skip-verify
+
+# Show help
+./.claude/setup-test-env.sh --help
+```
+
+### Environment Variables
+
+- `CLX_SKIP_DOWNLOADS=1` - Skip downloading PlantUML and DrawIO (useful in restricted networks)
+
+Example:
+```bash
+export CLX_SKIP_DOWNLOADS=1
+./.claude/setup-test-env.sh
+```
+
+## Output
+
+The script provides colored output:
+- **Blue** - Section headers and info messages
+- **Green** - Success messages (✓)
+- **Yellow** - Warning messages (⚠)
+- **Red** - Error messages (✗)
+
+## Success Criteria
+
+When successful, you should see:
+
+```
+===================================
+Environment Setup Complete ✓
+===================================
+All checks passed! Your environment is ready for running CLX tests.
+
+You can now run tests with:
+  pytest                    # Unit tests only (fast)
+  pytest -m integration     # Integration tests
+  pytest -m e2e            # End-to-end tests
+  pytest -m ""              # All tests
+```
+
+## Troubleshooting
+
+### Downloads Fail
+
+If downloads fail due to network restrictions:
+1. Set `export CLX_SKIP_DOWNLOADS=1`
+2. Follow manual installation instructions in CLAUDE.md
+
+### Verification Fails
+
+If some checks fail but core packages are installed:
+- You can still run unit tests
+- Integration/E2E tests may fail if external tools are missing
+
+### Permission Issues
+
+The script requires write access to:
+- `/usr/local/bin/` (for tool symlinks)
+- `/usr/local/share/` (for PlantUML JAR)
+- `/tmp/` (for temporary files)
+- `~/.bashrc` (for environment variables)
+
+Run as root or with sudo if needed.
+
+## After Setup
+
+Environment variables are added to `~/.bashrc`. To apply them to your current shell:
+
+```bash
+source ~/.bashrc
+```
+
+Or simply open a new shell session.
+
+## Integration with Claude Code
+
+This script is designed to be:
+1. **Run manually** when you need a test environment
+2. **Referenced in CLAUDE.md** for AI assistants to know about it
+3. **Independent of sessionStart hook** which only does basic package installation
+
+The sessionStart hook (`.claude/sessionStart`) handles basic package installation during session startup, while this script handles the complete test environment setup including external tools.
+
+## Maintenance
+
+When updating tool versions:
+1. Update version numbers in the script (PLANTUML_VERSION, DRAWIO_VERSION)
+2. Test the script with new versions
+3. Update CLAUDE.md if setup instructions change
+
+## See Also
+
+- `CLAUDE.md` - Full documentation including manual setup instructions
+- `.claude/sessionStart` - Session startup hook for basic package installation
+- `docs/developer-guide/testing.md` - Testing guide
+
+---
+
+**Last Updated**: 2025-11-16
+**Related Issue**: Integration test dependencies setup automation

--- a/.claude/setup-test-env.sh
+++ b/.claude/setup-test-env.sh
@@ -1,0 +1,407 @@
+#!/bin/bash
+# CLX Test Environment Setup Script
+#
+# This script automates the setup of a complete development and testing environment
+# for the CLX project. It handles:
+#   - Installing CLX package with all dependencies needed for testing
+#   - Installing worker service packages
+#   - Installing external tools (PlantUML, DrawIO)
+#   - Setting up Xvfb for headless DrawIO rendering
+#   - Setting required environment variables
+#   - Verifying the environment is working
+#
+# Usage:
+#   ./.claude/setup-test-env.sh
+#
+# Options:
+#   --skip-verify    Skip environment verification at the end
+#   --help           Show this help message
+#
+# Environment Variables:
+#   CLX_SKIP_DOWNLOADS=1    Skip downloading external tools (useful in restricted environments)
+
+set -e  # Exit on error
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Configuration
+PLANTUML_VERSION="1.2024.6"
+DRAWIO_VERSION="24.7.5"
+SKIP_VERIFY=false
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --skip-verify)
+            SKIP_VERIFY=true
+            shift
+            ;;
+        --help)
+            head -n 20 "$0" | grep "^#" | sed 's/^# \?//'
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1"
+            echo "Run with --help for usage information"
+            exit 1
+            ;;
+    esac
+done
+
+# Helper functions
+print_header() {
+    echo ""
+    echo -e "${BLUE}===================================${NC}"
+    echo -e "${BLUE}$1${NC}"
+    echo -e "${BLUE}===================================${NC}"
+}
+
+print_step() {
+    echo ""
+    echo -e "${BLUE}=== $1 ===${NC}"
+}
+
+print_success() {
+    echo -e "${GREEN}✓ $1${NC}"
+}
+
+print_warning() {
+    echo -e "${YELLOW}⚠ $1${NC}"
+}
+
+print_error() {
+    echo -e "${RED}✗ $1${NC}"
+}
+
+print_info() {
+    echo -e "  $1"
+}
+
+# Start
+print_header "CLX Test Environment Setup"
+echo "Timestamp: $(date '+%Y-%m-%d %H:%M:%S')"
+echo "Working directory: $(pwd)"
+echo "User: $(whoami)"
+
+# Verify we're in the CLX repository root
+if [ ! -f "pyproject.toml" ] || [ ! -d "src/clx" ]; then
+    print_error "This script must be run from the CLX repository root directory"
+    exit 1
+fi
+
+print_success "Running from CLX repository root"
+
+# Step 1: Install CLX package with all dependencies
+print_step "Step 1/7: Installing CLX package with all dependencies"
+print_info "This includes test dependencies, TUI, web, and development tools"
+
+if python -m pip install -q -e ".[all]"; then
+    print_success "CLX package installed with all extras"
+else
+    print_error "Failed to install CLX package"
+    exit 1
+fi
+
+# Verify clx command is available
+if command -v clx &> /dev/null; then
+    print_success "clx command is available: $(which clx)"
+else
+    print_warning "clx command not found in PATH (this might be OK if using 'python -m clx.cli')"
+fi
+
+# Step 2: Install worker service packages
+print_step "Step 2/7: Installing worker service packages"
+
+services=("notebook-processor" "drawio-converter" "plantuml-converter")
+for service in "${services[@]}"; do
+    print_info "Installing $service..."
+    if python -m pip install -q -e "./services/$service"; then
+        print_success "$service installed"
+    else
+        print_error "Failed to install $service"
+        exit 1
+    fi
+done
+
+# Step 3: Install PlantUML
+print_step "Step 3/7: Installing PlantUML"
+
+PLANTUML_JAR="/usr/local/share/plantuml-${PLANTUML_VERSION}.jar"
+REPO_PLANTUML_JAR="services/plantuml-converter/plantuml-${PLANTUML_VERSION}.jar"
+
+if [ -f "$PLANTUML_JAR" ] && [ $(stat -c%s "$PLANTUML_JAR") -gt 1000000 ]; then
+    print_success "PlantUML already installed at: $PLANTUML_JAR"
+else
+    # Check if repository file exists and is not a Git LFS pointer
+    if [ -f "$REPO_PLANTUML_JAR" ] && ! grep -q "git-lfs.github.com" "$REPO_PLANTUML_JAR" 2>/dev/null; then
+        print_info "Using PlantUML JAR from repository..."
+        cp "$REPO_PLANTUML_JAR" "$PLANTUML_JAR"
+        print_success "PlantUML installed from repository: $PLANTUML_JAR"
+    elif [ -z "$CLX_SKIP_DOWNLOADS" ]; then
+        print_info "Downloading PlantUML from GitHub releases..."
+        print_info "(Repository file is a Git LFS pointer or missing)"
+
+        if wget -q --show-progress --timeout=120 \
+            "https://github.com/plantuml/plantuml/releases/download/v${PLANTUML_VERSION}/plantuml-${PLANTUML_VERSION}.jar" \
+            -O "$PLANTUML_JAR"; then
+
+            # Verify the download
+            if [ -f "$PLANTUML_JAR" ] && [ $(stat -c%s "$PLANTUML_JAR") -gt 1000000 ]; then
+                print_success "PlantUML downloaded successfully: $PLANTUML_JAR ($(stat -c%s "$PLANTUML_JAR" | numfmt --to=iec-i)B)"
+            else
+                print_error "PlantUML download failed (file too small or missing)"
+                rm -f "$PLANTUML_JAR"
+                print_warning "PlantUML will not be available. Integration/E2E tests requiring PlantUML will fail."
+            fi
+        else
+            print_error "Failed to download PlantUML"
+            rm -f "$PLANTUML_JAR"
+            print_warning "PlantUML will not be available. Integration/E2E tests requiring PlantUML will fail."
+        fi
+    else
+        print_warning "Skipping PlantUML download (CLX_SKIP_DOWNLOADS is set)"
+        print_warning "PlantUML will not be available. Integration/E2E tests requiring PlantUML will fail."
+    fi
+fi
+
+# Create PlantUML wrapper script
+if [ -f "$PLANTUML_JAR" ]; then
+    if [ ! -f /usr/local/bin/plantuml ]; then
+        print_info "Creating PlantUML wrapper script..."
+        cat > /usr/local/bin/plantuml << 'EOF'
+#!/bin/bash
+PLANTUML_JAR="/usr/local/share/plantuml-1.2024.6.jar"
+exec java -DPLANTUML_LIMIT_SIZE=8192 -jar "$PLANTUML_JAR" "$@"
+EOF
+        chmod +x /usr/local/bin/plantuml
+        print_success "PlantUML wrapper script created at /usr/local/bin/plantuml"
+    else
+        print_success "PlantUML wrapper script already exists"
+    fi
+
+    # Test PlantUML
+    if java -version &> /dev/null; then
+        print_success "Java is available for PlantUML"
+    else
+        print_error "Java is not available - PlantUML will not work"
+    fi
+fi
+
+# Step 4: Install DrawIO
+print_step "Step 4/7: Installing DrawIO"
+
+DRAWIO_DEB="/tmp/drawio-amd64-${DRAWIO_VERSION}.deb"
+REPO_DRAWIO_DEB="services/drawio-converter/drawio-amd64-${DRAWIO_VERSION}.deb"
+
+if command -v drawio &> /dev/null; then
+    print_success "DrawIO already installed at: $(which drawio)"
+else
+    if [ -f "$DRAWIO_DEB" ] && [ $(stat -c%s "$DRAWIO_DEB") -gt 1000000 ]; then
+        print_info "Using cached DrawIO .deb at $DRAWIO_DEB"
+    else
+        # Check if repository file exists and is not a Git LFS pointer
+        if [ -f "$REPO_DRAWIO_DEB" ] && ! grep -q "git-lfs.github.com" "$REPO_DRAWIO_DEB" 2>/dev/null; then
+            print_info "Using DrawIO .deb from repository..."
+            cp "$REPO_DRAWIO_DEB" "$DRAWIO_DEB"
+        elif [ -z "$CLX_SKIP_DOWNLOADS" ]; then
+            print_info "Downloading DrawIO from GitHub releases..."
+            print_info "(Repository file is a Git LFS pointer or missing)"
+
+            if wget -q --show-progress --timeout=120 \
+                "https://github.com/jgraph/drawio-desktop/releases/download/v${DRAWIO_VERSION}/drawio-amd64-${DRAWIO_VERSION}.deb" \
+                -O "$DRAWIO_DEB"; then
+
+                # Verify the download
+                if [ -f "$DRAWIO_DEB" ] && [ $(stat -c%s "$DRAWIO_DEB") -lt 1000000 ]; then
+                    print_error "DrawIO download failed (file too small: $(stat -c%s "$DRAWIO_DEB") bytes)"
+                    rm -f "$DRAWIO_DEB"
+                else
+                    print_success "DrawIO downloaded successfully: $DRAWIO_DEB ($(stat -c%s "$DRAWIO_DEB" | numfmt --to=iec-i)B)"
+                fi
+            else
+                print_error "Failed to download DrawIO"
+                rm -f "$DRAWIO_DEB"
+            fi
+        else
+            print_warning "Skipping DrawIO download (CLX_SKIP_DOWNLOADS is set)"
+        fi
+    fi
+
+    # Extract DrawIO binary
+    if [ -f "$DRAWIO_DEB" ] && [ $(stat -c%s "$DRAWIO_DEB") -gt 1000000 ]; then
+        print_info "Extracting DrawIO binary..."
+        dpkg -x "$DRAWIO_DEB" /tmp/drawio-extract
+        ln -sf /tmp/drawio-extract/opt/drawio/drawio /usr/local/bin/drawio
+        print_success "DrawIO installed at /usr/local/bin/drawio"
+    else
+        print_warning "DrawIO will not be available. Integration/E2E tests requiring DrawIO will fail."
+    fi
+fi
+
+# Step 5: Setup Xvfb for headless DrawIO rendering
+print_step "Step 5/7: Setting up Xvfb for headless rendering"
+
+if pgrep -x Xvfb > /dev/null; then
+    XVFB_PID=$(pgrep -x Xvfb)
+    print_success "Xvfb is already running (PID: $XVFB_PID)"
+else
+    print_info "Starting Xvfb on display :99..."
+    if Xvfb :99 -screen 0 1024x768x24 -ac +extension GLX +render -noreset &> /tmp/xvfb.log &
+    then
+        sleep 2  # Give Xvfb time to start
+        if pgrep -x Xvfb > /dev/null; then
+            XVFB_PID=$(pgrep -x Xvfb)
+            print_success "Xvfb started successfully (PID: $XVFB_PID)"
+        else
+            print_error "Xvfb failed to start. Check /tmp/xvfb.log for details"
+        fi
+    else
+        print_error "Failed to start Xvfb"
+    fi
+fi
+
+# Step 6: Set environment variables
+print_step "Step 6/7: Setting environment variables"
+
+# Set PLANTUML_JAR if PlantUML is installed
+if [ -f "$PLANTUML_JAR" ]; then
+    export PLANTUML_JAR="$PLANTUML_JAR"
+    print_success "PLANTUML_JAR=$PLANTUML_JAR"
+
+    # Add to .bashrc for persistence
+    if ! grep -q "PLANTUML_JAR" ~/.bashrc 2>/dev/null; then
+        echo "export PLANTUML_JAR=\"$PLANTUML_JAR\"" >> ~/.bashrc
+        print_info "Added PLANTUML_JAR to ~/.bashrc"
+    fi
+fi
+
+# Set DISPLAY for Xvfb
+export DISPLAY=:99
+print_success "DISPLAY=$DISPLAY"
+
+# Add to .bashrc for persistence
+if ! grep -q "DISPLAY=:99" ~/.bashrc 2>/dev/null; then
+    echo "export DISPLAY=:99" >> ~/.bashrc
+    print_info "Added DISPLAY to ~/.bashrc"
+fi
+
+# Optional: Set DRAWIO_EXECUTABLE explicitly
+if command -v drawio &> /dev/null; then
+    export DRAWIO_EXECUTABLE=$(which drawio)
+    print_success "DRAWIO_EXECUTABLE=$DRAWIO_EXECUTABLE"
+fi
+
+print_info ""
+print_info "Environment variables are set for this session and added to ~/.bashrc"
+print_info "To apply them to your current shell, run: source ~/.bashrc"
+
+# Step 7: Verify environment
+if [ "$SKIP_VERIFY" = false ]; then
+    print_step "Step 7/7: Verifying environment"
+
+    ALL_OK=true
+
+    # Check Python packages
+    print_info "Checking Python packages..."
+    if python -c "import clx; print(f'  clx version: {clx.__version__}')" 2>/dev/null; then
+        print_success "CLX package is importable"
+    else
+        print_error "CLX package is not importable"
+        ALL_OK=false
+    fi
+
+    # Check worker packages
+    # Note: notebook-processor package is imported as "nb"
+    if python -c "import nb" 2>/dev/null; then
+        print_success "nb (notebook processor) package is importable"
+    else
+        print_error "nb (notebook processor) package is not importable"
+        ALL_OK=false
+    fi
+
+    for service in "drawio_converter" "plantuml_converter"; do
+        if python -c "import $service" 2>/dev/null; then
+            print_success "$service package is importable"
+        else
+            print_error "$service package is not importable"
+            ALL_OK=false
+        fi
+    done
+
+    # Check external tools
+    print_info ""
+    print_info "Checking external tools..."
+
+    # Java (required for PlantUML)
+    if java -version &> /dev/null; then
+        JAVA_VERSION=$(java -version 2>&1 | head -n 1)
+        print_success "Java is available: $JAVA_VERSION"
+    else
+        print_error "Java is not available (required for PlantUML)"
+        ALL_OK=false
+    fi
+
+    # PlantUML
+    if [ -f "$PLANTUML_JAR" ]; then
+        print_success "PlantUML JAR exists: $PLANTUML_JAR"
+        if command -v plantuml &> /dev/null; then
+            print_success "plantuml command is available"
+        else
+            print_warning "plantuml command not found (wrapper script may be missing)"
+        fi
+    else
+        print_warning "PlantUML JAR not found (PlantUML tests will fail)"
+    fi
+
+    # DrawIO
+    if command -v drawio &> /dev/null; then
+        print_success "DrawIO command is available: $(which drawio)"
+    else
+        print_warning "DrawIO not found (DrawIO tests will fail)"
+    fi
+
+    # Xvfb
+    if pgrep -x Xvfb > /dev/null; then
+        print_success "Xvfb is running (required for headless DrawIO)"
+    else
+        print_error "Xvfb is not running (required for DrawIO tests)"
+        ALL_OK=false
+    fi
+
+    # DISPLAY variable
+    if [ -n "$DISPLAY" ]; then
+        print_success "DISPLAY environment variable is set: $DISPLAY"
+    else
+        print_error "DISPLAY environment variable is not set"
+        ALL_OK=false
+    fi
+
+    # Summary
+    print_info ""
+    if [ "$ALL_OK" = true ]; then
+        print_header "Environment Setup Complete ✓"
+        echo -e "${GREEN}All checks passed! Your environment is ready for running CLX tests.${NC}"
+        echo ""
+        echo "You can now run tests with:"
+        echo "  pytest                    # Unit tests only (fast)"
+        echo "  pytest -m integration     # Integration tests"
+        echo "  pytest -m e2e            # End-to-end tests"
+        echo "  pytest -m \"\"              # All tests"
+    else
+        print_header "Environment Setup Complete (with warnings)"
+        echo -e "${YELLOW}Some checks failed. See warnings above.${NC}"
+        echo "You may still be able to run unit tests, but integration/e2e tests may fail."
+    fi
+else
+    print_info "Skipping verification (--skip-verify flag set)"
+    print_header "Environment Setup Complete"
+fi
+
+echo ""
+echo "For more information, see CLAUDE.md"
+echo ""

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -280,6 +280,28 @@ from clx.cli.main import cli
 
 ## Testing Framework
 
+### Quick Start: Automated Environment Setup
+
+**For Claude Code on the web or new development environments**, use the automated setup script:
+
+```bash
+# Run the automated setup script
+./.claude/setup-test-env.sh
+```
+
+This script automatically handles:
+- Installing CLX package with all testing dependencies
+- Installing worker service packages (notebook-processor, plantuml-converter, drawio-converter)
+- Downloading and installing PlantUML JAR
+- Downloading and installing DrawIO desktop application
+- Starting Xvfb for headless rendering
+- Setting environment variables (PLANTUML_JAR, DISPLAY, DRAWIO_EXECUTABLE)
+- Verifying the complete environment is working
+
+**After setup completes**, you can run all tests including integration and e2e tests.
+
+**Manual Setup**: If you prefer manual setup or the automated script fails, see sections below for detailed instructions.
+
 ### Pytest Configuration
 
 **Test Markers** (defined in `pyproject.toml`):
@@ -295,12 +317,7 @@ markers = [
 
 ### Running Tests
 
-**Prerequisites**: Install with `[all]` extra dependencies before running tests:
-```bash
-pip install -e ".[all]"
-```
-
-This ensures all optional dependencies (textual, rich, fastapi, etc.) are available for testing.
+**Prerequisites**: Environment must be set up with all dependencies (use `./.claude/setup-test-env.sh` or manual setup below)
 
 **Running tests**:
 ```bash
@@ -323,7 +340,11 @@ CLX_ENABLE_TEST_LOGGING=1 pytest -m e2e
 pytest tests/test_course.py
 ```
 
-### Xvfb Setup (Required for DrawIO Worker)
+### Manual Setup Instructions
+
+**Note**: The automated setup script (`./.claude/setup-test-env.sh`) handles all of these steps automatically. Use these manual instructions only if the automated script fails or you need to customize your setup.
+
+#### Xvfb Setup (Required for DrawIO Worker)
 
 The DrawIO converter requires a display server for headless rendering. In remote/headless environments (like Claude Code on the web), you need to start **Xvfb** (X virtual framebuffer).
 
@@ -332,7 +353,7 @@ The DrawIO converter requires a display server for headless rendering. In remote
 - Running integration tests that use DrawIO converter
 - Running e2e tests that process Draw.io diagrams
 
-**Starting Xvfb:**
+**Starting Xvfb manually:**
 
 ```bash
 # Start Xvfb on display :99 (runs in background)
@@ -359,9 +380,7 @@ pgrep -x Xvfb
 pkill Xvfb
 ```
 
-**Note**: The sessionStart hook does NOT automatically start Xvfb. You must start it manually when needed for DrawIO-related tasks.
-
-### PlantUML Setup (Required for PlantUML Worker)
+#### PlantUML Setup (Required for PlantUML Worker)
 
 The PlantUML converter requires the PlantUML JAR file and Java Runtime Environment.
 
@@ -370,10 +389,10 @@ The PlantUML converter requires the PlantUML JAR file and Java Runtime Environme
 - Running integration tests that use PlantUML converter
 - Running e2e tests that process PlantUML diagrams
 
-**Installing PlantUML:**
+**Installing PlantUML manually:**
 
 ```bash
-# 1. Download PlantUML JAR (if not already installed by sessionStart hook)
+# 1. Download PlantUML JAR
 PLANTUML_VERSION="1.2024.6"
 wget "https://github.com/plantuml/plantuml/releases/download/v${PLANTUML_VERSION}/plantuml-${PLANTUML_VERSION}.jar" \
   -O /usr/local/share/plantuml-${PLANTUML_VERSION}.jar
@@ -408,9 +427,7 @@ echo $PLANTUML_JAR
 **Required Dependencies:**
 - Java Runtime Environment (JRE) 8 or higher
 
-**Note**: The sessionStart hook attempts to install PlantUML automatically in remote environments. Manual installation is only needed if automatic installation fails or in local environments.
-
-### DrawIO Setup (Required for DrawIO Worker)
+#### DrawIO Setup (Required for DrawIO Worker)
 
 The DrawIO converter requires the DrawIO desktop application and Xvfb for headless rendering.
 
@@ -419,10 +436,10 @@ The DrawIO converter requires the DrawIO desktop application and Xvfb for headle
 - Running integration tests that use DrawIO converter
 - Running e2e tests that process Draw.io diagrams
 
-**Installing DrawIO:**
+**Installing DrawIO manually:**
 
 ```bash
-# 1. Download DrawIO .deb package (if not already installed by sessionStart hook)
+# 1. Download DrawIO .deb package
 DRAWIO_VERSION="24.7.5"
 wget "https://github.com/jgraph/drawio-desktop/releases/download/v${DRAWIO_VERSION}/drawio-amd64-${DRAWIO_VERSION}.deb" \
   -O /tmp/drawio-amd64-${DRAWIO_VERSION}.deb
@@ -461,8 +478,6 @@ echo $DISPLAY
 - Xvfb (X virtual framebuffer)
 - Various system libraries (usually available in Debian-based systems)
 
-**Note**: The sessionStart hook attempts to install DrawIO automatically in remote environments. Manual installation is only needed if automatic installation fails or in local environments. **DrawIO always requires Xvfb to be started manually** (see Xvfb Setup section above).
-
 ### Test Organization
 
 - **Unit tests**: Fast, mocked dependencies, no markers
@@ -486,6 +501,26 @@ Automatic logging for tests with `e2e` or `integration` markers.
 
 ### Initial Setup
 
+**Automated Setup (Recommended for Claude Code on the web):**
+
+```bash
+# Clone repository
+git clone https://github.com/hoelzl/clx.git
+cd clx
+
+# Run automated setup script
+./.claude/setup-test-env.sh
+
+# This installs everything needed for development and testing:
+# - CLX package with all dependencies
+# - Worker service packages
+# - External tools (PlantUML, DrawIO)
+# - Xvfb for headless rendering
+# - Environment variables
+```
+
+**Manual Setup (Local development):**
+
 ```bash
 # Clone repository
 git clone https://github.com/hoelzl/clx.git
@@ -506,48 +541,40 @@ clx --help
 python -c "from clx import Course; print('✓ CLX installed successfully!')"
 ```
 
-**Important**: When running tests or using monitoring features, install with `[all]` extra to ensure all optional dependencies are available.
+**Important**:
+- For running tests, use `./.claude/setup-test-env.sh` or manually install with `[all]` extra
+- The `[all]` extra includes all optional dependencies (textual, rich, fastapi, etc.)
 
 ### Native Worker Setup (Direct Execution Mode)
 
-The CLX project includes native workers that can run directly on your system (without Docker). The sessionStart hook automatically attempts to install the required external tools in remote environments.
+The CLX project includes native workers that can run directly on your system (without Docker).
+
+**Automated Setup**: Use `./.claude/setup-test-env.sh` to automatically install all required tools.
 
 **External Tools Required:**
 - **PlantUML** - For converting PlantUML diagrams to images
 - **DrawIO** - For converting Draw.io diagrams to images
 - **Xvfb** - For headless rendering of DrawIO diagrams
 
-**Automatic Installation by sessionStart Hook:**
-
-In remote environments (Claude Code on the web), the sessionStart hook will attempt to:
-1. Download PlantUML JAR from GitHub releases or use the repository file if Git LFS is set up
-2. Download DrawIO .deb package from GitHub releases or use the repository file if Git LFS is set up
-3. Install both tools to standard locations
-
-**⚠️ Note**: If downloads fail (e.g., GitHub access restrictions), you'll need to install manually. See instructions below.
+**Manual Setup**: See "Manual Setup Instructions" in the Testing Framework section above.
 
 **Skipping Downloads:**
 
-In restricted environments where downloads always fail, you can skip download attempts entirely:
+If you're in a restricted environment and want to skip download attempts in the setup script:
 
 ```bash
-# Set environment variable before running sessionStart
+# Set environment variable before running setup
 export CLX_SKIP_DOWNLOADS=1
 
-# Or set it in your shell configuration
-echo 'export CLX_SKIP_DOWNLOADS=1' >> ~/.bashrc
+# Then run setup
+./.claude/setup-test-env.sh
 ```
-
-This will:
-- Skip all download attempts (faster execution)
-- Show clear messages that tools are not available
-- Direct you to manual installation instructions
 
 **Git LFS Files in Repository:**
 - `services/plantuml-converter/plantuml-1.2024.6.jar` - PlantUML JAR file (Git LFS pointer, 22MB actual)
 - `services/drawio-converter/drawio-amd64-24.7.5.deb` - DrawIO Debian package (Git LFS pointer, 98MB actual)
 
-If these files are Git LFS pointers, the sessionStart hook will fall back to downloading from GitHub releases (unless `CLX_SKIP_DOWNLOADS` is set).
+The setup script will use these files if available (and not Git LFS pointers), otherwise download from GitHub releases.
 
 ### Running the CLI
 


### PR DESCRIPTION
Problem:
- Setting up integration test environment in Claude Code on the web required many manual steps
- Instructions in CLAUDE.md were scattered and inconsistent
- AI assistants wasted effort trying to install dependencies manually

Solution:
- Created .claude/setup-test-env.sh - comprehensive automated setup script that handles:
  * Installing CLX package with all dependencies ([all] extras)
  * Installing worker service packages (notebook, plantuml, drawio)
  * Downloading and installing PlantUML JAR
  * Downloading and installing DrawIO Debian package
  * Starting Xvfb for headless rendering
  * Setting environment variables (PLANTUML_JAR, DISPLAY, DRAWIO_EXECUTABLE)
  * Verifying all components work correctly

- Updated CLAUDE.md:
  * Added "Quick Start: Automated Environment Setup" section at top of Testing Framework
  * Consolidated manual setup instructions under "Manual Setup Instructions"
  * Updated Development Workflow to reference automated setup
  * Removed redundant and outdated information
  * Fixed package import name (notebook_worker -> nb)

- Added .claude/SETUP_SCRIPT_README.md documenting script usage

Benefits:
- One command to set up complete test environment
- Consistent, reproducible setup
- Works in restricted environments with CLX_SKIP_DOWNLOADS flag
- Clear verification of what's installed and working
- AI assistants can now easily set up test environments

Testing:
- Script tested successfully in current environment
- All verification checks pass
- Environment ready for integration and e2e tests