### PR TITLE
Fix database file creation in clx build

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -750,9 +750,13 @@ When making significant architectural changes:
 
 ### Database
 
-- **SQLite databases**:
-  - `clx_jobs.db` or `jobs.db` - Job queue
-  - `clx_cache.db` - Results cache (gitignored)
+- **SQLite databases** (two separate databases):
+  - `clx_jobs.db` - Job queue database (stores jobs, workers, events, results_cache tables)
+  - `clx_cache.db` - Cache database (stores processed_files table with pickled results)
+- **Why two databases**:
+  - Different lifetimes (job queue is ephemeral, cache persists)
+  - Different access patterns (job queue is write-heavy, cache is read-heavy)
+  - Reduced lock contention for better concurrency
 - **Thread safety**: SQLite has WAL mode enabled for concurrent access
 - **Connection pooling**: Not needed, lightweight connections
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -215,8 +215,11 @@ CLX uses TOML format for configuration files. Here's a complete example:
 # CLX Configuration File
 
 [paths]
-# Path to the SQLite database for job queue
-db_path = "clx_cache.db"
+# Path to the cache database (stores processed file results)
+cache_db_path = "clx_cache.db"
+
+# Path to the job queue database (stores jobs, workers, events)
+jobs_db_path = "clx_jobs.db"
 
 # Workspace path for workers (optional, usually derived from output directory)
 workspace_path = ""
@@ -298,7 +301,8 @@ CLX settings can also be configured via environment variables. Environment varia
 
 **Examples**:
 ```bash
-export CLX_PATHS__DB_PATH="/tmp/clx_cache.db"
+export CLX_PATHS__CACHE_DB_PATH="/tmp/clx_cache.db"
+export CLX_PATHS__JOBS_DB_PATH="/tmp/clx_jobs.db"
 export CLX_LOGGING__LOG_LEVEL="DEBUG"
 export CLX_LOGGING__TESTING__E2E_PROGRESS_INTERVAL="5"
 ```
@@ -318,10 +322,15 @@ export JINJA_LINE_STATEMENT_PREFIX="# custom"
 
 #### Paths Configuration
 
-**CLX_PATHS__DB_PATH**
-- **Description**: Path to SQLite job queue database
+**CLX_PATHS__CACHE_DB_PATH**
+- **Description**: Path to cache database (stores processed file results)
 - **Default**: `clx_cache.db`
-- **Example**: `export CLX_PATHS__DB_PATH="/tmp/clx_jobs.db"`
+- **Example**: `export CLX_PATHS__CACHE_DB_PATH="/tmp/clx_cache.db"`
+
+**CLX_PATHS__JOBS_DB_PATH**
+- **Description**: Path to job queue database (stores jobs, workers, events)
+- **Default**: `clx_jobs.db`
+- **Example**: `export CLX_PATHS__JOBS_DB_PATH="/tmp/clx_jobs.db"`
 
 **CLX_PATHS__WORKSPACE_PATH**
 - **Description**: Workspace path for workers

--- a/src/clx/infrastructure/config.py
+++ b/src/clx/infrastructure/config.py
@@ -93,9 +93,14 @@ class LegacyEnvSettingsSource(PydanticBaseSettingsSource):
 class PathsConfig(BaseModel):
     """Path-related configuration."""
 
-    db_path: str = Field(
+    cache_db_path: str = Field(
         default="clx_cache.db",
-        description="Path to the SQLite database for job queue",
+        description="Path to the cache database (stores processed file results)",
+    )
+
+    jobs_db_path: str = Field(
+        default="clx_jobs.db",
+        description="Path to the job queue database (stores jobs, workers, events)",
     )
 
     workspace_path: str = Field(
@@ -614,14 +619,18 @@ def create_example_config() -> str:
 # Nested settings use double underscores: CLX_<SECTION>__<KEY>
 #
 # Examples:
-#   CLX_PATHS__DB_PATH=/tmp/jobs.db
+#   CLX_PATHS__CACHE_DB_PATH=/tmp/cache.db
+#   CLX_PATHS__JOBS_DB_PATH=/tmp/jobs.db
 #   CLX_LOGGING__LOG_LEVEL=DEBUG
 #   PLANTUML_JAR=/usr/local/share/plantuml.jar
 #   DRAWIO_EXECUTABLE=/usr/local/bin/drawio
 
 [paths]
-# Path to the SQLite database for job queue
-db_path = "clx_cache.db"
+# Path to the cache database (stores processed file results)
+cache_db_path = "clx_cache.db"
+
+# Path to the job queue database (stores jobs, workers, events)
+jobs_db_path = "clx_jobs.db"
 
 # Workspace path for workers (optional, usually derived from output directory)
 workspace_path = ""

--- a/tests/cli/test_cli_unit.py
+++ b/tests/cli/test_cli_unit.py
@@ -206,33 +206,40 @@ class TestDeleteDatabaseCommand:
             result = runner.invoke(
                 cli,
                 [
-                    "--db-path",
-                    "nonexistent.db",
+                    "--cache-db-path",
+                    "nonexistent_cache.db",
+                    "--jobs-db-path",
+                    "nonexistent_jobs.db",
                     "delete-database",
                 ],
             )
             assert result.exit_code == 0
-            assert "No database found" in result.output
+            assert "No databases found" in result.output
 
     def test_delete_database_when_exists(self):
         """Test delete_database when database exists"""
         runner = CliRunner()
         with runner.isolated_filesystem():
-            # Create a dummy database file
-            db_path = Path("test.db")
-            db_path.write_text("dummy")
+            # Create dummy database files
+            cache_db_path = Path("test_cache.db")
+            jobs_db_path = Path("test_jobs.db")
+            cache_db_path.write_text("dummy")
+            jobs_db_path.write_text("dummy")
 
             result = runner.invoke(
                 cli,
                 [
-                    "--db-path",
-                    str(db_path),
+                    "--cache-db-path",
+                    str(cache_db_path),
+                    "--jobs-db-path",
+                    str(jobs_db_path),
                     "delete-database",
                 ],
             )
             assert result.exit_code == 0
-            assert "has been deleted" in result.output
-            assert not db_path.exists()
+            assert "Deleted:" in result.output
+            assert not cache_db_path.exists()
+            assert not jobs_db_path.exists()
 
 
 class TestCliIsolation:


### PR DESCRIPTION
This change properly separates the job queue database from the cache database, as originally intended in the design. The two databases serve different purposes with different lifetimes and access patterns.

Changes:
- CLI: Replace --db-path with --cache-db-path and --jobs-db-path options
- Config: Split paths.db_path into cache_db_path and jobs_db_path
- Main: Use jobs_db_path for job queue, cache_db_path for cache manager
- delete-database: Add --which option to select cache/jobs/both
- config show: Display both database paths
- Tests: Update all configuration and CLI tests
- Docs: Update CLAUDE.md and user guide configuration docs

Database separation:
- clx_jobs.db: Job queue (jobs, workers, events) - ephemeral
- clx_cache.db: Processed file cache - persistent across sessions

Benefits:
- Different lifetimes (job queue vs persistent cache)
- Reduced lock contention for better concurrency
- Clear separation of concerns
- Easier database management

Fixes: #51