### PR TITLE
Move results cache to correct database

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -751,8 +751,8 @@ When making significant architectural changes:
 ### Database
 
 - **SQLite databases** (two separate databases):
-  - `clx_jobs.db` - Job queue database (stores jobs, workers, events, results_cache tables)
-  - `clx_cache.db` - Cache database (stores processed_files table with pickled results)
+  - `clx_jobs.db` - Job queue database (stores jobs, workers, worker_events, schema_version tables)
+  - `clx_cache.db` - Cache database (stores processed_files and results_cache tables)
 - **Why two databases**:
   - Different lifetimes (job queue is ephemeral, cache persists)
   - Different access patterns (job queue is write-heavy, cache is read-heavy)

--- a/services/drawio-converter/src/drawio_converter/drawio_worker.py
+++ b/services/drawio-converter/src/drawio_converter/drawio_worker.py
@@ -11,6 +11,7 @@ import asyncio
 import sqlite3
 import time
 from pathlib import Path
+from typing import Optional
 from base64 import b64decode, b64encode
 
 # Add clx-common to path if running standalone
@@ -23,6 +24,7 @@ from clx.infrastructure.database.schema import init_database
 # Configuration
 LOG_LEVEL = os.environ.get("LOG_LEVEL", "INFO").upper()
 DB_PATH = Path(os.environ.get("DB_PATH", "/db/jobs.db"))
+CACHE_DB_PATH = Path(os.environ.get("CACHE_DB_PATH", os.environ.get("DB_PATH", "/db/cache.db")))
 
 # Logging setup
 logging.basicConfig(
@@ -35,14 +37,15 @@ logger = logging.getLogger(__name__)
 class DrawioWorker(Worker):
     """Worker that processes DrawIO conversion jobs from SQLite queue."""
 
-    def __init__(self, worker_id: int, db_path: Path):
+    def __init__(self, worker_id: int, db_path: Path, cache_db_path: Optional[Path] = None):
         """Initialize DrawIO worker.
 
         Args:
             worker_id: Worker ID from database
-            db_path: Path to SQLite database
+            db_path: Path to SQLite job queue database
+            cache_db_path: Path to SQLite cache database (optional)
         """
-        super().__init__(worker_id, 'drawio', db_path)
+        super().__init__(worker_id, 'drawio', db_path, cache_db_path=cache_db_path)
         # Create persistent event loop for this worker
         self._loop = None
         logger.info(f"DrawioWorker {worker_id} initialized")
@@ -253,7 +256,7 @@ def main():
     worker_id = register_worker(DB_PATH)
 
     # Create and run worker
-    worker = DrawioWorker(worker_id, DB_PATH)
+    worker = DrawioWorker(worker_id, DB_PATH, cache_db_path=CACHE_DB_PATH)
 
     try:
         worker.run()

--- a/src/clx/cli/main.py
+++ b/src/clx/cli/main.py
@@ -155,6 +155,7 @@ async def main(
 
         backend = SqliteBackend(
             db_path=jobs_db_path,
+            cache_db_path=cache_db_path,
             workspace_path=output_dir,
             db_manager=db_manager,
             ignore_db=ignore_db

--- a/src/clx/infrastructure/backends/sqlite_backend.py
+++ b/src/clx/infrastructure/backends/sqlite_backend.py
@@ -31,6 +31,7 @@ class SqliteBackend(LocalOpsBackend):
     """
 
     db_path: Path = Path('clx_jobs.db')
+    cache_db_path: Optional[Path] = None
     workspace_path: Path = Path.cwd()
     job_queue: JobQueue | None = field(init=False, default=None)
     db_manager: DatabaseManager | None = None
@@ -46,8 +47,12 @@ class SqliteBackend(LocalOpsBackend):
         """Initialize SQLite database and job queue."""
         # Database should already be initialized, but ensure it exists
         init_database(self.db_path)
-        self.job_queue = JobQueue(self.db_path)
-        logger.info(f"Initialized SQLite backend with database: {self.db_path}")
+
+        # Use cache_db_path if provided, otherwise use db_path for backward compatibility
+        actual_cache_db_path = self.cache_db_path or self.db_path
+
+        self.job_queue = JobQueue(self.db_path, cache_db_path=actual_cache_db_path)
+        logger.info(f"Initialized SQLite backend with job queue DB: {self.db_path}, cache DB: {actual_cache_db_path}")
 
         # Initialize progress tracker if enabled
         if self.enable_progress_tracking:

--- a/src/clx/infrastructure/database/schema.py
+++ b/src/clx/infrastructure/database/schema.py
@@ -41,21 +41,6 @@ CREATE TABLE IF NOT EXISTS jobs (
 CREATE INDEX IF NOT EXISTS idx_jobs_status ON jobs(status, job_type);
 CREATE INDEX IF NOT EXISTS idx_jobs_content_hash ON jobs(content_hash);
 
--- Results cache table
-CREATE TABLE IF NOT EXISTS results_cache (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    output_file TEXT NOT NULL,
-    content_hash TEXT NOT NULL,
-    result_metadata TEXT,  -- JSON
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    last_accessed TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    access_count INTEGER DEFAULT 0,
-
-    UNIQUE(output_file, content_hash)
-);
-
-CREATE INDEX IF NOT EXISTS idx_cache_lookup ON results_cache(output_file, content_hash);
-
 -- Workers table
 CREATE TABLE IF NOT EXISTS workers (
     id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/src/clx/infrastructure/workers/worker_base.py
+++ b/src/clx/infrastructure/workers/worker_base.py
@@ -32,6 +32,7 @@ class Worker(ABC):
         worker_id: int,
         worker_type: str,
         db_path: Path,
+        cache_db_path: Optional[Path] = None,
         poll_interval: float = 0.1,
         job_timeout: Optional[float] = None
     ):
@@ -40,16 +41,18 @@ class Worker(ABC):
         Args:
             worker_id: Unique worker ID (from workers table)
             worker_type: Type of jobs to process ('notebook', 'drawio', 'plantuml')
-            db_path: Path to SQLite database
+            db_path: Path to SQLite job queue database
+            cache_db_path: Path to SQLite cache database (optional, defaults to db_path)
             poll_interval: Time to wait between polls when no jobs available (seconds)
             job_timeout: Maximum time a job can run before being considered hung (seconds, default: None = no timeout)
         """
         self.worker_id = worker_id
         self.worker_type = worker_type
         self.db_path = db_path
+        self.cache_db_path = cache_db_path or db_path
         self.poll_interval = poll_interval
         self.job_timeout = job_timeout or float('inf')  # Default to infinity (no timeout)
-        self.job_queue = JobQueue(db_path)
+        self.job_queue = JobQueue(db_path, cache_db_path=self.cache_db_path)
         self.running = True
         self._last_heartbeat = datetime.now()
 

--- a/tests/infrastructure/workers/test_worker_base.py
+++ b/tests/infrastructure/workers/test_worker_base.py
@@ -17,8 +17,8 @@ from clx.infrastructure.workers.worker_base import Worker
 class MockWorker(Worker):
     """Mock worker implementation for testing."""
 
-    def __init__(self, worker_id: int, db_path: Path, poll_interval: float = 0.1):
-        super().__init__(worker_id, 'test', db_path, poll_interval)
+    def __init__(self, worker_id: int, db_path: Path, cache_db_path = None, poll_interval: float = 0.1):
+        super().__init__(worker_id, 'test', db_path, cache_db_path=cache_db_path, poll_interval=poll_interval)
         self.processed_jobs = []
         self.should_fail = False
         self.process_delay = 0.0
@@ -103,7 +103,8 @@ def test_worker_initialization(worker_id, db_path):
 
 def test_worker_custom_poll_interval(worker_id, db_path):
     """Test worker with custom poll interval."""
-    worker = MockWorker(worker_id, db_path, poll_interval=0.5)
+    # cache_db_path is optional, poll_interval is a keyword argument
+    worker = MockWorker(worker_id, db_path, cache_db_path=None, poll_interval=0.5)
     assert worker.poll_interval == 0.5
 
 


### PR DESCRIPTION
This commit reorganizes the database structure to move the results_cache table from the job queue database (clx_jobs.db) to the cache database (clx_cache.db).

Changes:
- Removed results_cache table and idx_cache_lookup index from job queue schema (schema.py)
- Added results_cache table and index to cache DB schema (db_operations.py)
- Updated JobQueue to accept cache_db_path parameter and create separate cache DB connection
- Updated check_cache() and add_to_cache() methods in JobQueue to use cache DB connection instead of jobs DB connection
- Updated SqliteBackend to pass cache_db_path to JobQueue
- Updated Worker base class to accept and forward cache_db_path
- Updated all three worker services (notebook, plantuml, drawio) to pass cache_db_path from CACHE_DB_PATH environment variable
- Updated CLI to pass cache_db_path to SqliteBackend
- Fixed tests to reflect new database structure
- Updated CLAUDE.md documentation

The separation improves database organization by keeping lightweight job metadata cache (results_cache) alongside full result cache (processed_files) in the cache database, while keeping job queue operations in the jobs database.

All 157 infrastructure tests pass.