### PR TITLE
Fix invalid file paths on Windows by sanitizing notebook titles

### DIFF
--- a/src/clx/core/course_files/notebook_file.py
+++ b/src/clx/core/course_files/notebook_file.py
@@ -8,7 +8,7 @@ from clx.infrastructure.operation import Concurrently, Operation
 from clx.core.topic import Topic
 from clx.core.utils.notebook_utils import find_notebook_titles
 from clx.infrastructure.utils.path_utils import ext_for, extension_to_prog_lang, output_specs
-from clx.core.utils.text_utils import Text
+from clx.core.utils.text_utils import Text, sanitize_file_name
 
 if TYPE_CHECKING:
     from clx.core.course import Course
@@ -49,4 +49,5 @@ class NotebookFile(CourseFile):
         return extension_to_prog_lang(self.path.suffix)
 
     def file_name(self, lang: str, ext: str) -> str:
-        return f"{self.number_in_section:02} {self.title[lang]}{ext}"
+        sanitized_title = sanitize_file_name(self.title[lang])
+        return f"{self.number_in_section:02} {sanitized_title}{ext}"


### PR DESCRIPTION
## Summary
Fixes Windows file path errors caused by unsanitized notebook titles containing invalid characters (colons, etc.).

## Problem
Notebook titles with colons (e.g., "05 Deep Dive: Neural Networks in Detail") were being used directly in output file paths without sanitization, causing `NotADirectoryError: [WinError 267] The directory name is invalid` on Windows.

The codebase already had a `sanitize_file_name()` function, but it wasn't being applied to notebook titles when constructing output file names in `NotebookFile.file_name()` (src/clx/core/course_files/notebook_file.py:52).

## Solution
- Import and apply `sanitize_file_name()` to notebook titles before using them in file paths
- This removes/replaces Windows-invalid characters:
  - Colons (`:`) are deleted
  - Slashes (`/`, `\`), brackets (`<`, `>`), asterisks (`*`), pipes (`|`) are replaced with underscores
  - Other special characters are handled per the existing sanitization rules

## Files Changed
- `src/clx/core/course_files/notebook_file.py` - Added sanitization to `file_name()` method

**Note**: PlantUML and DrawIO files already had proper path sanitization using `sanitize_path()` function.

## Testing
- All existing tests pass (20 tests in `tests/core/course_files/`)
- Verified sanitization works correctly with problematic characters

🤖 Generated with [Claude Code](https://claude.com/claude-code)