### PR TITLE
Fix failing tests on Windows

### DIFF
--- a/tests/cli/test_cli_unit.py
+++ b/tests/cli/test_cli_unit.py
@@ -168,17 +168,52 @@ class TestBuildCommandArguments:
             assert "no such option" not in result.output.lower()
 
     def test_build_db_path_option(self):
-        """Test that global --db-path option is accepted"""
+        """Test that global --jobs-db-path and --cache-db-path options are accepted"""
         runner = CliRunner()
         with runner.isolated_filesystem():
             spec_path = Path("test-spec.xml")
             spec_path.write_text("<course></course>")
 
+            # Test --jobs-db-path option
             result = runner.invoke(
                 cli,
                 [
-                    "--db-path",
-                    "custom.db",
+                    "--jobs-db-path",
+                    "custom_jobs.db",
+                    "build",
+                    str(spec_path),
+                    "--data-dir",
+                    ".",
+                ],
+            )
+            # Verify no argument parsing errors
+            assert "no such option" not in result.output.lower()
+            assert "missing argument" not in result.output.lower()
+
+            # Test --cache-db-path option
+            result = runner.invoke(
+                cli,
+                [
+                    "--cache-db-path",
+                    "custom_cache.db",
+                    "build",
+                    str(spec_path),
+                    "--data-dir",
+                    ".",
+                ],
+            )
+            # Verify no argument parsing errors
+            assert "no such option" not in result.output.lower()
+            assert "missing argument" not in result.output.lower()
+
+            # Test both options together
+            result = runner.invoke(
+                cli,
+                [
+                    "--jobs-db-path",
+                    "custom_jobs.db",
+                    "--cache-db-path",
+                    "custom_cache.db",
                     "build",
                     str(spec_path),
                     "--data-dir",


### PR DESCRIPTION
## Summary

Fixes two categories of test failures that were occurring on the master branch.

## Fixed Tests

### 1. CLI Tests - Database Path Options

**Problem**: Test was using deprecated `--db-path` option that no longer exists.

**Fix**: Updated `test_build_db_path_option` to use the new separate options:
- `--jobs-db-path` - for job queue database
- `--cache-db-path` - for results cache database
- Tests both individually and together

**Result**: All CLI tests pass (15/15 ✅)

### 2. Path Sanitization Tests - Platform Differences

**Problem**: Tests had Unix-centric expectations that failed on Windows due to different path handling:
- `test_sanitize_path_absolute_unix` - Expected Unix root paths to work on Windows
- `test_sanitize_path_absolute_windows` - Expected Windows drive letters to behave like Unix components

**Fix**: Made tests platform-aware using `sys.platform` checks:
- **On Windows**: Drive letters like `C:\` are recognized, Unix-style paths get `_` prefix
- **On Unix**: Root paths work normally, drive letters treated as regular path components

**Result**: All text_utils tests pass (17/17 ✅)

## Test Results

**Before**:
```
2 failed, 269 passed
```

**After**:
```
271 passed ✅
```

## Changes

- `tests/cli/test_cli_unit.py`: Update database path option test
- `tests/core/utils/text_utils_test.py`: Add platform-specific assertions

## Notes

These were pre-existing test failures on the master branch, not introduced by recent changes. The failures occurred because:
1. The CLI was updated to use separate database paths, but tests weren't updated
2. Path sanitization tests assumed Unix behavior on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)