### PR TITLE
Fix clx monitor application errors

### DIFF
--- a/src/clx/cli/monitor/data_provider.py
+++ b/src/clx/cli/monitor/data_provider.py
@@ -81,15 +81,15 @@ class DataProvider:
             cursor = conn.execute(
                 """
                 SELECT
-                    j.job_id,
+                    j.id,
                     j.status,
-                    j.document_path,
+                    j.input_file,
                     j.created_at,
                     j.started_at,
                     j.completed_at,
-                    w.worker_id,
+                    w.container_id,
                     CAST((julianday(j.completed_at) - julianday(j.started_at)) * 86400 AS INTEGER) as duration,
-                    j.error_message
+                    j.error
                 FROM jobs j
                 LEFT JOIN workers w ON w.id = j.worker_id
                 WHERE j.status IN ('processing', 'completed', 'failed')

--- a/src/clx/cli/monitor/widgets/activity_panel.py
+++ b/src/clx/cli/monitor/widgets/activity_panel.py
@@ -16,7 +16,7 @@ class ActivityPanel(Static):
     def __init__(self, **kwargs):
         """Initialize activity panel."""
         super().__init__(**kwargs)
-        self.events: list[ActivityEvent] = []
+        self._events_data: list[ActivityEvent] = []
 
     def compose(self) -> ComposeResult:
         """Create child widgets."""

--- a/src/clx/cli/monitor/widgets/workers_panel.py
+++ b/src/clx/cli/monitor/widgets/workers_panel.py
@@ -16,7 +16,7 @@ class WorkersPanel(Static):
     def __init__(self, **kwargs):
         """Initialize workers panel."""
         super().__init__(**kwargs)
-        self.workers: dict[str, WorkerTypeStats] = {}
+        self._workers_data: dict[str, WorkerTypeStats] = {}
 
     def compose(self) -> ComposeResult:
         """Create child widgets."""
@@ -29,7 +29,7 @@ class WorkersPanel(Static):
         Args:
             status: System status data
         """
-        self.workers = status.workers
+        self._workers_data = status.workers
         self._render_workers()
 
     def _render_workers(self) -> None:
@@ -37,13 +37,13 @@ class WorkersPanel(Static):
         content_widget = self.query_one("#workers-content", VerticalScroll)
         content_widget.remove_children()
 
-        if not self.workers:
+        if not self._workers_data:
             content_widget.mount(Static("[yellow]⚠ No workers registered[/yellow]"))
             return
 
         # Render each worker type
         for worker_type in ["notebook", "plantuml", "drawio"]:
-            if worker_type not in self.workers:
+            if worker_type not in self._workers_data:
                 # Show message for missing worker type
                 header = f"[dim]{worker_type.title()}[/dim] (0 workers)"
                 content_widget.mount(Static(header))
@@ -51,7 +51,7 @@ class WorkersPanel(Static):
                 content_widget.mount(Static(""))  # Blank line
                 continue
 
-            stats = self.workers[worker_type]
+            stats = self._workers_data[worker_type]
 
             # Worker type header
             mode = stats.execution_mode or "unknown"


### PR DESCRIPTION
## Summary

Fixes two categories of errors that prevented the `clx monitor` TUI application from starting.

## Issues Fixed

### 1. AttributeError: property 'workers' has no setter

**Error Message**:
```
AttributeError: property 'workers' of 'WorkersPanel' object has no setter
```

**Root Cause**: 
- `WorkersPanel` and `ActivityPanel` inherit from Textual's `Static` widget
- Textual reserves certain property names (like `workers`, `events`)
- Attempting to set these as instance variables in `__init__` caused conflicts

**Fix**:
- Renamed instance variables to use private naming convention with `_data` suffix:
  - `self.workers` → `self._workers_data` in WorkersPanel
  - `self.events` → `self._events_data` in ActivityPanel
- Updated all references to use the new names

### 2. SQL Query Column Name Errors

**Error Messages**:
```
sqlite3.OperationalError: no such column: j.job_id
sqlite3.OperationalError: no such column: j.document_path
```

**Root Cause**:
- SQL query in `data_provider.py` was using incorrect column names
- Didn't match the actual schema in the jobs table

**Incorrect → Correct Mappings**:
- `j.job_id` → `j.id`
- `j.document_path` → `j.input_file`  
- `w.worker_id` → `w.container_id`
- `j.error_message` → `j.error`

**Fix**:
- Updated SQL SELECT statement to use correct column names from the schema

## Changes

- `src/clx/cli/monitor/widgets/workers_panel.py`: Rename `workers` to `_workers_data`
- `src/clx/cli/monitor/widgets/activity_panel.py`: Rename `events` to `_events_data`
- `src/clx/cli/monitor/data_provider.py`: Fix SQL column names

## Testing

**Before**:
```bash
$ clx monitor
AttributeError: property 'workers' of 'WorkersPanel' object has no setter
```

**After**:
```bash
$ clx monitor
# Monitor starts successfully and displays UI
# No errors in logs ✅
```

## Notes

These errors affected the `clx monitor` command, which requires the `[tui]` optional dependencies (`textual`, `rich`). The monitor provides real-time visualization of:
- Worker status and health
- Job queue statistics
- Recent activity log

🤖 Generated with [Claude Code](https://claude.com/claude-code)