### PR TITLE
Improve error and warning reporting throughout CLX

### DIFF
--- a/src/clx/core/__init__.py
+++ b/src/clx/core/__init__.py
@@ -6,7 +6,7 @@ course structure, file types, and operations.
 
 from clx.core.course import Course
 from clx.core.course_file import CourseFile
-from clx.core.course_spec import CourseSpec
+from clx.core.course_spec import CourseSpec, CourseSpecError
 from clx.core.dir_group import DirGroup
 from clx.core.section import Section
 from clx.core.topic import Topic
@@ -15,6 +15,7 @@ __all__ = [
     "Course",
     "CourseFile",
     "CourseSpec",
+    "CourseSpecError",
     "DirGroup",
     "Section",
     "Topic",

--- a/src/clx/infrastructure/database/job_queue.py
+++ b/src/clx/infrastructure/database/job_queue.py
@@ -273,13 +273,16 @@ class JobQueue:
             conn.rollback()
             raise
 
-    def update_job_status(self, job_id: int, status: str, error: str | None = None):
+    def update_job_status(
+        self, job_id: int, status: str, error: str | None = None, result: str | None = None
+    ):
         """Update job status.
 
         Args:
             job_id: Job ID
             status: New status ('pending', 'processing', 'completed', 'failed')
-            error: Optional error message
+            error: Optional error message (JSON string for structured error info)
+            result: Optional result data (JSON string with warnings and other metadata)
         """
         conn = self._get_conn()
 
@@ -290,10 +293,10 @@ class JobQueue:
             conn.execute(
                 """
                 UPDATE jobs
-                SET status = ?, completed_at = CURRENT_TIMESTAMP, error = NULL
+                SET status = ?, completed_at = CURRENT_TIMESTAMP, error = NULL, result = ?
                 WHERE id = ?
                 """,
-                (status, job_id),
+                (status, result, job_id),
             )
             # No commit() needed - connection is in autocommit mode
 
@@ -311,10 +314,10 @@ class JobQueue:
             conn.execute(
                 """
                 UPDATE jobs
-                SET status = ?, error = ?
+                SET status = ?, error = ?, result = ?
                 WHERE id = ?
                 """,
-                (status, error, job_id),
+                (status, error, result, job_id),
             )
             # No commit() needed - connection is in autocommit mode
 

--- a/src/clx/infrastructure/messaging/base_classes.py
+++ b/src/clx/infrastructure/messaging/base_classes.py
@@ -2,7 +2,21 @@ import hashlib
 from abc import ABC, abstractmethod
 from typing import Any, Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
+
+
+class ProcessingWarning(BaseModel):
+    """A warning that occurred during processing.
+
+    Warnings represent non-fatal issues that should be reported to the user
+    but don't prevent processing from completing (or failing for other reasons).
+    """
+
+    category: str
+    message: str
+    severity: Literal["high", "medium", "low"] = "medium"
+    file_path: str = ""
+    details: dict[str, Any] = Field(default_factory=dict)
 
 
 class TransferModel(BaseModel, ABC):
@@ -44,6 +58,7 @@ class Result(TransferModel):
     output_file: str
     input_file: str
     content_hash: str
+    warnings: list[ProcessingWarning] = Field(default_factory=list)
 
     @abstractmethod
     def result_bytes(self) -> bytes: ...
@@ -70,6 +85,7 @@ class ProcessingError(TransferModel):
     input_file_name: str
     output_file: str
     traceback: str = ""
+    warnings: list[ProcessingWarning] = Field(default_factory=list)
 
 
 ImageResultOrError = ImageResult | ProcessingError

--- a/src/clx/workers/notebook/notebook_worker.py
+++ b/src/clx/workers/notebook/notebook_worker.py
@@ -140,6 +140,12 @@ class NotebookWorker(Worker):
             result = await processor.process_notebook(payload)
             logger.debug(f"Notebook processing complete for {input_path.name}")
 
+            # Collect warnings from the processor
+            warnings = processor.get_warnings()
+            if warnings:
+                logger.debug(f"Notebook processing generated {len(warnings)} warning(s)")
+                self.set_job_warnings(warnings)
+
             # Write output file
             output_path = Path(job.output_file)
             output_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/clx/workers/notebook/utils/jupyter_utils.py
+++ b/src/clx/workers/notebook/utils/jupyter_utils.py
@@ -111,8 +111,10 @@ def is_answer_cell(cell: Cell):
 def get_slide_tag(cell: Cell) -> str | None:
     """Return the slide tag of cell or `None` if it doesn't have one.
 
-    Raises an error if the slide has multiple slide tags."""
-
+    Note: If the cell has multiple slide tags, this logs a warning and
+    returns one arbitrarily. Use get_conflicting_slide_tags() to check
+    for this condition and report it properly.
+    """
     tags = get_tags(cell)
     slide_tags = _SLIDE_TAGS.intersection(tags)
     if slide_tags:
@@ -140,16 +142,63 @@ def is_cell_included_for_language(cell: Cell, lang: str) -> bool:
         return False
 
 
-def warn_on_invalid_code_tags(tags):
-    for tag in tags:
-        if tag not in _EXPECTED_CODE_TAGS:
-            logging.warning(f"Unknown tag for code cell: {tag!r}.")
+def get_invalid_code_tags(tags: list[str]) -> list[str]:
+    """Return list of invalid tags for a code cell.
+
+    Args:
+        tags: List of tags from the cell
+
+    Returns:
+        List of tags that are not valid for code cells
+    """
+    return [tag for tag in tags if tag not in _EXPECTED_CODE_TAGS]
 
 
-def warn_on_invalid_markdown_tags(tags):
-    for tag in tags:
-        if tag not in _EXPECTED_MARKDOWN_TAGS:
-            logging.warning(f"Unknown tag for markdown cell: {tag!r}.")
+def get_invalid_markdown_tags(tags: list[str]) -> list[str]:
+    """Return list of invalid tags for a markdown cell.
+
+    Args:
+        tags: List of tags from the cell
+
+    Returns:
+        List of tags that are not valid for markdown cells
+    """
+    return [tag for tag in tags if tag not in _EXPECTED_MARKDOWN_TAGS]
+
+
+def get_conflicting_slide_tags(tags: list[str]) -> list[str] | None:
+    """Check if tags contain multiple conflicting slide tags.
+
+    Args:
+        tags: List of tags from the cell
+
+    Returns:
+        List of conflicting slide tags if there are multiple, None otherwise
+    """
+    slide_tags = list(_SLIDE_TAGS.intersection(tags))
+    if len(slide_tags) > 1:
+        return slide_tags
+    return None
+
+
+def warn_on_invalid_code_tags(tags: list[str]) -> None:
+    """Log warnings for invalid code cell tags.
+
+    This function is kept for backward compatibility. Consider using
+    get_invalid_code_tags() to collect warnings for proper reporting.
+    """
+    for tag in get_invalid_code_tags(tags):
+        logging.warning(f"Unknown tag for code cell: {tag!r}.")
+
+
+def warn_on_invalid_markdown_tags(tags: list[str]) -> None:
+    """Log warnings for invalid markdown cell tags.
+
+    This function is kept for backward compatibility. Consider using
+    get_invalid_markdown_tags() to collect warnings for proper reporting.
+    """
+    for tag in get_invalid_markdown_tags(tags):
+        logging.warning(f"Unknown tag for markdown cell: {tag!r}.")
 
 
 _PARENS_TO_REPLACE = "{}[]"


### PR DESCRIPTION
## Summary

- Add comprehensive improvements to error/warning reporting for better user experience
- Tag validation warnings now surface to users with cell index information
- XML spec parsing errors provide user-friendly messages with line/column info
- Notebook execution errors include root cause and cell content context
- Errors and warnings are deduplicated in build summary
- Increased display limits: 10 errors (was 5), 5 warnings (was 3)
- Added severity color-coding for warnings

## Changes

### Messaging Protocol
- Add `ProcessingWarning` class for structured warnings
- Extend `Result` and `ProcessingError` with `warnings` field

### Tag Validation
- Tag validation warnings captured per cell with cell index
- Multiple slide tag conflicts now reported to users
- New functions: `get_invalid_code_tags()`, `get_invalid_markdown_tags()`, `get_conflicting_slide_tags()`

### Spec File Errors
- Added `CourseSpecError` exception with user-friendly messages
- XML parsing errors include line/column info and common causes

### Notebook Execution Errors
- Enhanced error context with root cause extraction
- Cell content snippets included in error messages
- Line numbers extracted from tracebacks

### Backend Integration
- Schema v6 migration adds `result` column for job warnings
- `SqliteBackend` extracts and reports warnings from completed jobs
- Warnings stored in database for cache retrieval

### Summary Output
- Errors and warnings deduplicated based on file_path + category + message
- 10 errors shown (up from 5)
- 5 warnings shown (up from 3)
- Less aggressive truncation (120 chars instead of 60-80)
- Prefer `actionable_guidance` in error display
- Severity color-coding: high=red, medium=yellow, low=dim yellow

## Test plan
- [x] All existing tests pass (1350 passed, 41 skipped)
- [x] Ruff linting and formatting passes
- [x] Mypy type checking passes
- [ ] Manual test with notebooks containing invalid tags
- [ ] Manual test with malformed spec files

🤖 Generated with [Claude Code](https://claude.com/claude-code)