### PR TITLE
Improve clx monitor UI and fix timestamp comparison

### DIFF
--- a/src/clx/cli/monitor/app.py
+++ b/src/clx/cli/monitor/app.py
@@ -52,11 +52,11 @@ class CLXMonitorApp(App):
     }
 
     #workers-panel {
-        width: 60%;
+        width: 70%;
     }
 
     #queue-panel {
-        width: 40%;
+        width: 30%;
     }
 
     #activity-panel {


### PR DESCRIPTION
## Summary

- Fix Job Queue showing 0 completed/failed jobs by using SQLite's `datetime('now', '-1 hour')` for proper timestamp comparison
- Redesign status header to show useful summary: health status, worker counts (busy/total), queue status, and completed jobs
- Improve worker display: compact format showing filename only, mode icon (◆ direct, ◇ docker), and relevant info
- Adjust panel widths (70%/30%) for better layout

## Test plan

- [x] Run `pytest tests/cli/` - all 225 tests pass
- [x] Run `ruff check` and `ruff format` - all files pass
- [ ] Manual testing with `clx monitor` during a build

🤖 Generated with [Claude Code](https://claude.com/claude-code)