### PR TITLE
Fix --ignore-db to still write results to cache

### DIFF
--- a/src/clx/cli/main.py
+++ b/src/clx/cli/main.py
@@ -1027,7 +1027,11 @@ def cli(ctx, cache_db_path, jobs_db_path):
     default="INFO",
     help="Set the logging level.",
 )
-@click.option("--ignore-db", is_flag=True, help="Ignore the database and process all files")
+@click.option(
+    "--ignore-db",
+    is_flag=True,
+    help="Ignore cached results and reprocess all files (still updates cache)",
+)
 @click.option(
     "--force-db-init",
     is_flag=True,

--- a/src/clx/infrastructure/backends/sqlite_backend.py
+++ b/src/clx/infrastructure/backends/sqlite_backend.py
@@ -337,7 +337,9 @@ class SqliteBackend(LocalOpsBackend):
                         self.progress_tracker.job_completed(job_id)
 
                     # Add to database cache if applicable
-                    if not self.ignore_db and self.db_manager:
+                    # Always store results in cache, even with --ignore-db
+                    # (ignore_db only affects reading, not writing - like error storage below)
+                    if self.db_manager:
                         output_path = Path(job_info["output_file"])
                         # Make path absolute relative to workspace if not already absolute
                         if not output_path.is_absolute():


### PR DESCRIPTION
## Summary

- Fixed the `--ignore-db` flag to only skip reading from the cache, while still writing new results
- Previously, the flag skipped both reading AND writing, causing stale cache entries to persist after regenerating files
- Updated help text to clarify the behavior: "Ignore cached results and reprocess all files (still updates cache)"

## Test plan

- [x] Verified existing tests pass (`tests/infrastructure/backends/test_sqlite_backend.py`, `tests/cli/test_cli_integration.py`)
- [ ] Manual test: Run `clx build --ignore-db`, then run without the flag to verify cached results are used

🤖 Generated with [Claude Code](https://claude.com/claude-code)