### PR TITLE
Fix Python 3.13 unclosed connection warnings and restore full Docker E2E tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,20 @@ jobs:
           -t clx-notebook-processor:lite-test \
           .
 
+    - name: Build plantuml-converter:test Docker image
+      run: |
+        docker build \
+          -f docker/plantuml/Dockerfile \
+          -t clx-plantuml-converter:test \
+          .
+
+    - name: Build drawio-converter:test Docker image
+      run: |
+        docker build \
+          -f docker/drawio/Dockerfile \
+          -t clx-drawio-converter:test \
+          .
+
     - name: Install uv
       uses: astral-sh/setup-uv@v4
       with:

--- a/tests/infrastructure/workers/test_event_logger.py
+++ b/tests/infrastructure/workers/test_event_logger.py
@@ -22,8 +22,7 @@ def temp_db():
         db_path = Path(f.name)
 
     # Initialize database
-    conn = init_database(db_path)
-    conn.close()
+    init_database(db_path)
 
     yield db_path
 


### PR DESCRIPTION
## Summary

- Fix `ResourceWarning` about unclosed database connections in Python 3.13 by making `init_database()` close its own connection instead of returning it
- Update all callers (JobQueue, SqliteBackend, test fixtures) to not expect a return value from `init_database()`
- Build all three Docker images (notebook, plantuml, drawio) in CI
- Restore Docker E2E tests to use full course with all file types (notebooks, PlantUML, Draw.io)

## Test plan

- [x] All unit tests pass locally
- [x] All integration tests pass locally
- [x] All E2E tests pass locally
- [ ] CI runs all tests successfully with Python 3.11, 3.12, and 3.13
- [ ] Docker integration tests build all three images and run E2E tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)