### PR TITLE
Fix remaining Python 3.13 unclosed database connection warnings

### DIFF
--- a/src/clx/infrastructure/workers/discovery.py
+++ b/src/clx/infrastructure/workers/discovery.py
@@ -41,6 +41,20 @@ class WorkerDiscovery:
         self.job_queue = JobQueue(db_path)
         self.executors = executors or {}
 
+    def close(self):
+        """Close database connection."""
+        if hasattr(self, "job_queue") and self.job_queue is not None:
+            self.job_queue.close()
+
+    def __enter__(self):
+        """Context manager entry."""
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Context manager exit."""
+        self.close()
+        return False
+
     def discover_workers(
         self,
         worker_type: str | None = None,

--- a/src/clx/infrastructure/workers/lifecycle_manager.py
+++ b/src/clx/infrastructure/workers/lifecycle_manager.py
@@ -93,6 +93,24 @@ class WorkerLifecycleManager:
         # Track managed workers (for cleanup)
         self.managed_workers: list[WorkerInfo] = []
 
+    def close(self):
+        """Close all database connections.
+
+        This method should be called when the lifecycle manager is no longer needed
+        to avoid ResourceWarning about unclosed database connections.
+        """
+        # Close event logger
+        if hasattr(self, "event_logger") and self.event_logger is not None:
+            self.event_logger.close()
+
+        # Close discovery
+        if hasattr(self, "discovery") and self.discovery is not None:
+            self.discovery.close()
+
+        # Close pool manager
+        if hasattr(self, "pool_manager") and self.pool_manager is not None:
+            self.pool_manager.close()
+
     def should_start_workers(self) -> bool:
         """Determine if we need to start new workers.
 

--- a/tests/e2e/test_e2e_course_conversion.py
+++ b/tests/e2e/test_e2e_course_conversion.py
@@ -399,19 +399,8 @@ async def db_path_fixture():
     init_database(path)
     yield path
 
-    # Cleanup
-    import gc
-    import sqlite3
-
-    gc.collect()
-
-    try:
-        conn = sqlite3.connect(path)
-        conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
-        conn.close()
-    except Exception:
-        pass
-
+    # Cleanup - the caller is responsible for closing any JobQueue/connections
+    # before this fixture tears down
     try:
         path.unlink(missing_ok=True)
         for suffix in ["-wal", "-shm"]:
@@ -478,8 +467,9 @@ async def sqlite_backend_with_notebook_workers(db_path_fixture, workspace_path_f
     async with backend:
         yield backend
 
-    # Cleanup
+    # Cleanup - stop workers and close database connections
     manager.stop_pools()
+    manager.close()
 
 
 @pytest.fixture
@@ -566,8 +556,9 @@ async def sqlite_backend_with_plantuml_workers(db_path_fixture, workspace_path_f
     async with backend:
         yield backend
 
-    # Cleanup
+    # Cleanup - stop workers and close database connections
     manager.stop_pools()
+    manager.close()
 
 
 @pytest.fixture
@@ -618,8 +609,9 @@ async def sqlite_backend_with_drawio_workers(db_path_fixture, workspace_path_fix
     async with backend:
         yield backend
 
-    # Cleanup
+    # Cleanup - stop workers and close database connections
     manager.stop_pools()
+    manager.close()
 
 
 @pytest.fixture
@@ -674,8 +666,9 @@ async def sqlite_backend_with_all_workers(db_path_fixture, workspace_path_fixtur
     async with backend:
         yield backend
 
-    # Cleanup
+    # Cleanup - stop workers and close database connections
     manager.stop_pools()
+    manager.close()
 
 
 @pytest.mark.e2e


### PR DESCRIPTION
## Summary

- Add proper resource cleanup for SQLite database connections across the worker infrastructure to eliminate `ResourceWarning` messages in Python 3.13's stricter garbage collection
- Add `close()` methods and context manager support to `WorkerDiscovery`, `WorkerPoolManager`, and `WorkerLifecycleManager`
- Fix `Worker.cleanup()` to close the job_queue connection alongside the event loop
- Fix `Worker.run()` to call `cleanup()` on exit for proper resource release
- Fix `Worker.register_worker_with_retry()` to close temporary JobQueue in finally block
- Update E2E test fixtures to properly close database connections instead of relying on `gc.collect()`

## Test plan

- [x] Run E2E tests without ResourceWarning errors: `pytest tests/e2e/ -m "e2e and not docker"`
- [x] Run integration tests: `pytest tests/ -m integration`
- [x] Run full test suite: `pytest tests/`
- [x] Verify linting passes: `ruff check src/ tests/`
- [x] Verify type checking passes: `mypy src/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)